### PR TITLE
[#5] Include inbound Frame in QueryLog

### DIFF
--- a/common/src/main/java/com/datastax/oss/simulacron/common/cluster/ActivityLog.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/cluster/ActivityLog.java
@@ -16,12 +16,7 @@
 package com.datastax.oss.simulacron.common.cluster;
 
 import com.datastax.oss.protocol.internal.Frame;
-import com.datastax.oss.protocol.internal.request.Execute;
-import com.datastax.oss.protocol.internal.request.Options;
-import com.datastax.oss.protocol.internal.request.Query;
-import com.datastax.oss.simulacron.common.codec.ConsistencyLevel;
 import com.datastax.oss.simulacron.common.stubbing.InternalStubMapping;
-import com.datastax.oss.simulacron.common.stubbing.Prime;
 import com.datastax.oss.simulacron.common.stubbing.StubMapping;
 import java.net.SocketAddress;
 import java.util.ArrayList;
@@ -34,55 +29,14 @@ public class ActivityLog {
   private List<QueryLog> queryLog = new ArrayList<QueryLog>();
 
   public QueryLog addLog(
-      Frame frame, SocketAddress socketAddress, Optional<StubMapping> stubOption, long timestamp) {
-    // TODO: Add field which indicates the type of message.
+      Frame frame, SocketAddress socketAddress, long timestamp, Optional<StubMapping> stubOption) {
     boolean isPrimed = false;
     if (stubOption.isPresent()) {
       StubMapping stub = stubOption.get();
       isPrimed = !(stub instanceof InternalStubMapping);
     }
-
-    QueryLog log = null;
-
-    if (frame.message instanceof Query) {
-      Query query = (Query) frame.message;
-
-      log =
-          new QueryLog(
-              query.query,
-              ConsistencyLevel.fromCode(query.options.consistency),
-              ConsistencyLevel.fromCode(query.options.serialConsistency),
-              socketAddress,
-              timestamp,
-              isPrimed);
-    } else if (frame.message instanceof Options) {
-      log = new QueryLog("OPTIONS", null, null, socketAddress, timestamp, stubOption.isPresent());
-    } else if (frame.message instanceof Execute) {
-      Execute execute = (Execute) frame.message;
-      if (stubOption.isPresent()) {
-        StubMapping stub = stubOption.get();
-        if (stub instanceof Prime) {
-          Prime prime = (Prime) stub;
-          if (prime.getPrimedRequest().when
-              instanceof com.datastax.oss.simulacron.common.request.Query) {
-            com.datastax.oss.simulacron.common.request.Query query =
-                (com.datastax.oss.simulacron.common.request.Query) prime.getPrimedRequest().when;
-            log =
-                new QueryLog(
-                    query.query,
-                    ConsistencyLevel.fromCode(execute.options.consistency),
-                    ConsistencyLevel.fromCode(execute.options.serialConsistency),
-                    socketAddress,
-                    timestamp,
-                    isPrimed);
-          }
-        }
-      }
-      // TODO: Record unknown execute.
-    }
-    if (log != null) {
-      queryLog.add(log);
-    }
+    QueryLog log = new QueryLog(frame, socketAddress, timestamp, isPrimed, stubOption);
+    queryLog.add(log);
     return log;
   }
 


### PR DESCRIPTION
Fixes #5 

This is a bit of a stop gap until the query log is completely refactored as described in #6.  Adds `getFrame()` to `QueryLog` so we can inspect the inbound message completely, checking things like protocol version, flags used and so on.