### PR TITLE
Differentiate between the `then` affecting the prepared statement and the bound statement

### DIFF
--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/AlreadyExistsResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/AlreadyExistsResult.java
@@ -31,7 +31,7 @@ public class AlreadyExistsResult extends ErrorResult {
   private final String table;
 
   public AlreadyExistsResult(String errorMessage, String keyspace, String table) {
-    this(errorMessage, keyspace, table, 0, false);
+    this(errorMessage, keyspace, table, 0, null);
   }
 
   @JsonCreator
@@ -40,7 +40,7 @@ public class AlreadyExistsResult extends ErrorResult {
       @JsonProperty(value = "keyspace", required = true) String keyspace,
       @JsonProperty(value = "table", required = true) String table,
       @JsonProperty("delayInMs") long delayInMs,
-      @JsonProperty("ignore_on_prepare") boolean ignoreOnPrepare) {
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
     super(ALREADY_EXISTS, errorMessage, delayInMs, ignoreOnPrepare);
     this.keyspace = keyspace;
     this.table = table;

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/AuthenticationErrorResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/AuthenticationErrorResult.java
@@ -22,13 +22,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class AuthenticationErrorResult extends ErrorResult {
 
   public AuthenticationErrorResult(String errorMessage) {
-    this(errorMessage, 0, false);
+    this(errorMessage, 0, null);
   }
 
   public AuthenticationErrorResult(
       @JsonProperty(value = "message", required = true) String errorMessage,
       @JsonProperty("delay_in_ms") long delayInMs,
-      @JsonProperty("ignore_on_prepare") boolean ignoreOnPrepare) {
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
     super(AUTH_ERROR, errorMessage, delayInMs, ignoreOnPrepare);
   }
 }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/CloseConnectionResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/CloseConnectionResult.java
@@ -20,6 +20,7 @@ import com.datastax.oss.simulacron.common.cluster.AbstractNode;
 import com.datastax.oss.simulacron.common.stubbing.Action;
 import com.datastax.oss.simulacron.common.stubbing.CloseType;
 import com.datastax.oss.simulacron.common.stubbing.DisconnectAction;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Collections;
 import java.util.List;
@@ -32,11 +33,17 @@ public class CloseConnectionResult extends Result {
   @JsonProperty("close_type")
   private final CloseType closeType;
 
+  public CloseConnectionResult(DisconnectAction.Scope scope, CloseType closeType) {
+    this(scope, closeType, 0, null);
+  }
+
+  @JsonCreator
   public CloseConnectionResult(
       @JsonProperty("scope") DisconnectAction.Scope scope,
       @JsonProperty("close_type") CloseType closeType,
-      @JsonProperty("delay_in_ms") long delayInMs) {
-    super(delayInMs);
+      @JsonProperty("delay_in_ms") long delayInMs,
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
+    super(delayInMs, ignoreOnPrepare);
     this.scope = scope;
     this.closeType = closeType;
   }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/ConfigurationErrorResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/ConfigurationErrorResult.java
@@ -23,14 +23,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class ConfigurationErrorResult extends ErrorResult {
 
   public ConfigurationErrorResult(String errorMessage) {
-    this(errorMessage, 0, false);
+    this(errorMessage, 0, null);
   }
 
   @JsonCreator
   public ConfigurationErrorResult(
       @JsonProperty(value = "message", required = true) String errorMessage,
       @JsonProperty("delay_in_ms") long delayInMs,
-      @JsonProperty("ignore_on_prepare") boolean ignoreOnPrepare) {
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
     super(CONFIG_ERROR, errorMessage, delayInMs, ignoreOnPrepare);
   }
 }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/ErrorResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/ErrorResult.java
@@ -31,16 +31,12 @@ public abstract class ErrorResult extends Result {
   @JsonProperty("message")
   protected final String errorMessage;
 
-  @JsonProperty("ignore_on_prepare")
-  protected final boolean ignoreOnPrepare;
-
   @JsonIgnore private final transient int errorCode;
 
-  ErrorResult(int errorCode, String errorMessage, long delayInMs, boolean ignoreOnPrepare) {
-    super(delayInMs);
+  ErrorResult(int errorCode, String errorMessage, long delayInMs, Boolean ignoreOnPrepare) {
+    super(delayInMs, ignoreOnPrepare);
     this.errorCode = errorCode;
     this.errorMessage = errorMessage;
-    this.ignoreOnPrepare = ignoreOnPrepare;
   }
 
   public String getErrorMessage() {
@@ -58,10 +54,6 @@ public abstract class ErrorResult extends Result {
 
   public Message toMessage() {
     return new Error(getErrorCode(), getErrorMessage());
-  }
-
-  public boolean isIgnoreOnPrepare() {
-    return ignoreOnPrepare;
   }
 
   @Override

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/ErrorResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/ErrorResult.java
@@ -60,7 +60,7 @@ public abstract class ErrorResult extends Result {
     return new Error(getErrorCode(), getErrorMessage());
   }
 
-  public boolean isignoreOnPrepare() {
+  public boolean isIgnoreOnPrepare() {
     return ignoreOnPrepare;
   }
 

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/FunctionFailureResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/FunctionFailureResult.java
@@ -36,7 +36,7 @@ public class FunctionFailureResult extends ErrorResult {
 
   public FunctionFailureResult(
       String keyspace, String function, List<String> argTypes, String detail) {
-    this(keyspace, function, argTypes, detail, 0, false);
+    this(keyspace, function, argTypes, detail, 0, null);
   }
 
   @JsonCreator
@@ -46,7 +46,7 @@ public class FunctionFailureResult extends ErrorResult {
       @JsonProperty("arg_types") List<String> argTypes,
       @JsonProperty("detail") String detail,
       @JsonProperty("delay_in_ms") long delayInMs,
-      @JsonProperty("ignore_on_prepare") boolean ignoreOnPrepare) {
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
     super(
         FUNCTION_FAILURE,
         "execution of '" + functionName(keyspace, function) + argTypes + "' failed: " + detail,

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/InvalidResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/InvalidResult.java
@@ -23,14 +23,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class InvalidResult extends ErrorResult {
 
   public InvalidResult(String errorMessage) {
-    this(errorMessage, 0, false);
+    this(errorMessage, 0, null);
   }
 
   @JsonCreator
   public InvalidResult(
       @JsonProperty(value = "message", required = true) String errorMessage,
       @JsonProperty("delay_in_ms") long delayInMs,
-      @JsonProperty("ignore_on_prepare") boolean ignoreOnPrepare) {
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
     super(INVALID, errorMessage, delayInMs, ignoreOnPrepare);
   }
 }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/IsBootstrappingResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/IsBootstrappingResult.java
@@ -23,13 +23,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class IsBootstrappingResult extends ErrorResult {
 
   public IsBootstrappingResult() {
-    this(0, false);
+    this(0, null);
   }
 
   @JsonCreator
   public IsBootstrappingResult(
       @JsonProperty("delay_in_ms") long delayInMs,
-      @JsonProperty("ignore_on_prepare") boolean ignoreOnPrepare) {
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
     super(IS_BOOTSTRAPPING, "Cannot read from a bootstrapping node", delayInMs, ignoreOnPrepare);
   }
 }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/NoResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/NoResult.java
@@ -25,7 +25,7 @@ import java.util.List;
 public class NoResult extends Result {
 
   public NoResult() {
-    super(0);
+    super(0, null);
   }
 
   @Override

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/OverloadedResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/OverloadedResult.java
@@ -23,14 +23,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class OverloadedResult extends ErrorResult {
 
   public OverloadedResult(String errorMessage) {
-    this(errorMessage, 0, false);
+    this(errorMessage, 0, null);
   }
 
   @JsonCreator
   public OverloadedResult(
       @JsonProperty(value = "message", required = true) String errorMessage,
       @JsonProperty("delay_in_ms") long delayInMs,
-      @JsonProperty("ignore_on_prepare") boolean ignoreOnPrepare) {
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
     super(OVERLOADED, errorMessage, delayInMs, ignoreOnPrepare);
   }
 }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/ProtocolErrorResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/ProtocolErrorResult.java
@@ -22,13 +22,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class ProtocolErrorResult extends ErrorResult {
 
   public ProtocolErrorResult(String errorMessage) {
-    this(errorMessage, 0, false);
+    this(errorMessage, 0, null);
   }
 
   public ProtocolErrorResult(
       @JsonProperty(value = "message", required = true) String errorMessage,
       @JsonProperty("delay_in_ms") long delayInMs,
-      @JsonProperty("ignore_on_prepare") boolean ignoreOnPrepare) {
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
     super(PROTOCOL_ERROR, errorMessage, delayInMs, ignoreOnPrepare);
   }
 }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/ReadFailureResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/ReadFailureResult.java
@@ -37,7 +37,7 @@ public class ReadFailureResult extends RequestFailureResult {
       int blockFor,
       Map<InetAddress, RequestFailureReason> failureReasonByEndpoint,
       boolean dataPresent) {
-    this(cl, received, blockFor, failureReasonByEndpoint, dataPresent, 0, false);
+    this(cl, received, blockFor, failureReasonByEndpoint, dataPresent, 0, null);
   }
 
   @JsonCreator
@@ -49,7 +49,7 @@ public class ReadFailureResult extends RequestFailureResult {
           Map<InetAddress, RequestFailureReason> failureReasonByEndpoint,
       @JsonProperty(value = "data_present", required = true) boolean dataPresent,
       @JsonProperty("delay_in_ms") long delayInMs,
-      @JsonProperty("ignore_on_prepare") boolean ignoreOnPrepare) {
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
     super(
         READ_FAILURE, cl, received, blockFor, failureReasonByEndpoint, delayInMs, ignoreOnPrepare);
     this.dataPresent = dataPresent;

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/ReadTimeoutResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/ReadTimeoutResult.java
@@ -29,7 +29,7 @@ public class ReadTimeoutResult extends RequestTimeoutResult {
   private final boolean dataPresent;
 
   public ReadTimeoutResult(ConsistencyLevel cl, int received, int blockFor, boolean dataPresent) {
-    this(cl, received, blockFor, dataPresent, 0, false);
+    this(cl, received, blockFor, dataPresent, 0, null);
   }
 
   @JsonCreator
@@ -39,7 +39,7 @@ public class ReadTimeoutResult extends RequestTimeoutResult {
       @JsonProperty(value = "block_for", required = true) int blockFor,
       @JsonProperty(value = "data_present", required = true) boolean dataPresent,
       @JsonProperty("delay_in_ms") long delayInMs,
-      @JsonProperty("ignore_on_prepare") boolean ignoreOnPrepare) {
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
     super(READ_TIMEOUT, cl, received, blockFor, delayInMs, ignoreOnPrepare);
     this.dataPresent = dataPresent;
   }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/RequestFailureResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/RequestFailureResult.java
@@ -36,9 +36,6 @@ public abstract class RequestFailureResult extends ErrorResult {
   @JsonProperty("failure_reasons")
   protected final Map<InetAddress, RequestFailureReason> failureReasonByEndpoint;
 
-  @JsonProperty("ignore_on_prepare")
-  boolean ignoreOnPrepare;
-
   protected RequestFailureResult(
       int errorCode,
       ConsistencyLevel cl,
@@ -46,7 +43,7 @@ public abstract class RequestFailureResult extends ErrorResult {
       int blockFor,
       Map<InetAddress, RequestFailureReason> failureReasonByEndpoint,
       long delayInMs,
-      boolean ignoreOnPrepare) {
+      Boolean ignoreOnPrepare) {
     super(
         errorCode,
         String.format(

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/RequestTimeoutResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/RequestTimeoutResult.java
@@ -29,16 +29,13 @@ public abstract class RequestTimeoutResult extends ErrorResult {
   @JsonProperty("block_for")
   protected final int blockFor;
 
-  @JsonProperty("ignore_on_prepare")
-  boolean ignoreOnPrepare;
-
   protected RequestTimeoutResult(
       int errorCode,
       ConsistencyLevel cl,
       int received,
       int blockFor,
       long delayInMs,
-      boolean ignoreOnPrepare) {
+      Boolean ignoreOnPrepare) {
     super(
         errorCode,
         String.format("Operation timed out - received only %d responses.", received),

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/Result.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/Result.java
@@ -56,9 +56,15 @@ public abstract class Result {
   @JsonProperty("delay_in_ms")
   protected long delayInMs;
 
+  @JsonProperty("ignore_on_prepare")
+  protected Boolean ignoreOnPrepare;
+
   @JsonCreator
-  public Result(@JsonProperty("delay_in_ms") long delayInMs) {
+  public Result(
+      @JsonProperty("delay_in_ms") long delayInMs,
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
     this.delayInMs = delayInMs;
+    this.ignoreOnPrepare = ignoreOnPrepare;
   }
 
   @JsonIgnore
@@ -68,6 +74,26 @@ public abstract class Result {
 
   public void setDelay(long delay, TimeUnit delayUnit) {
     this.delayInMs = TimeUnit.MILLISECONDS.convert(delay, delayUnit);
+  }
+
+  /**
+   * @return Whether or not this result should be applied to a matching prepare statement. Note that
+   *     in the case of {@link SuccessResult} this only applies to delay, as we do not want to
+   *     return rows responses for prepare messages.
+   */
+  public boolean isIgnoreOnPrepare() {
+    // if not set, return true as that should be the default behavior.
+    return ignoreOnPrepare == null ? true : ignoreOnPrepare;
+  }
+
+  /**
+   * Sets whether or not this result should be applied to a matching prepare statement.
+   *
+   * @param ignoreOnPrepare Value to set.
+   */
+  @JsonIgnore
+  public void setIgnoreOnPrepare(boolean ignoreOnPrepare) {
+    this.ignoreOnPrepare = ignoreOnPrepare;
   }
 
   public abstract List<Action> toActions(AbstractNode node, Frame frame);

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/ServerErrorResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/ServerErrorResult.java
@@ -23,14 +23,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class ServerErrorResult extends ErrorResult {
 
   public ServerErrorResult(String errorMessage) {
-    this(errorMessage, 0, false);
+    this(errorMessage, 0, null);
   }
 
   @JsonCreator
   public ServerErrorResult(
       @JsonProperty(value = "message", required = true) String errorMessage,
       @JsonProperty("delay_in_ms") long delayInMs,
-      @JsonProperty("ignore_on_prepare") boolean ignoreOnPrepare) {
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
     super(SERVER_ERROR, errorMessage, delayInMs, ignoreOnPrepare);
   }
 }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/SuccessResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/SuccessResult.java
@@ -44,15 +44,16 @@ public class SuccessResult extends Result {
   public final Map<String, String> columnTypes;
 
   public SuccessResult(List<Map<String, Object>> rows, Map<String, String> columnTypes) {
-    this(rows, columnTypes, 0);
+    this(rows, columnTypes, 0, null);
   }
 
   @JsonCreator
   public SuccessResult(
       @JsonProperty("rows") List<Map<String, Object>> rows,
       @JsonProperty("column_types") Map<String, String> columnTypes,
-      @JsonProperty("delay_in_ms") long delayInMs) {
-    super(delayInMs);
+      @JsonProperty("delay_in_ms") long delayInMs,
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
+    super(delayInMs, ignoreOnPrepare);
     if ((rows != null) ^ (columnTypes != null)) {
       throw new IllegalArgumentException(
           "Both \"rows\" and \"columnTypes\" are required or none of them");

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/SyntaxErrorResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/SyntaxErrorResult.java
@@ -23,14 +23,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class SyntaxErrorResult extends ErrorResult {
 
   public SyntaxErrorResult(String errorMessage) {
-    this(errorMessage, 0, false);
+    this(errorMessage, 0, null);
   }
 
   @JsonCreator
   public SyntaxErrorResult(
       @JsonProperty(value = "message", required = true) String errorMessage,
       @JsonProperty("delay_in_ms") long delayInMs,
-      @JsonProperty("ignore_on_prepare") boolean ignoreOnPrepare) {
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
     super(SYNTAX_ERROR, errorMessage, delayInMs, ignoreOnPrepare);
   }
 }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/TruncateErrorResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/TruncateErrorResult.java
@@ -23,14 +23,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class TruncateErrorResult extends ErrorResult {
 
   public TruncateErrorResult(String message) {
-    this(message, 0, false);
+    this(message, 0, null);
   }
 
   @JsonCreator
   public TruncateErrorResult(
       @JsonProperty(value = "message", required = true) String errorMessage,
       @JsonProperty("delay_in_ms") long delayInMs,
-      @JsonProperty("ignore_on_prepare") boolean ignoreOnPrepare) {
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
     super(TRUNCATE_ERROR, errorMessage, delayInMs, ignoreOnPrepare);
   }
 }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/UnauthorizedResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/UnauthorizedResult.java
@@ -23,14 +23,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class UnauthorizedResult extends ErrorResult {
 
   public UnauthorizedResult(String errorMessage) {
-    this(errorMessage, 0, false);
+    this(errorMessage, 0, null);
   }
 
   @JsonCreator
   public UnauthorizedResult(
       @JsonProperty(value = "message", required = true) String errorMessage,
       @JsonProperty("delay_in_ms") long delayInMs,
-      @JsonProperty("ignore_on_prepare") boolean ignoreOnPrepare) {
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
     super(UNAUTHORIZED, errorMessage, delayInMs, ignoreOnPrepare);
   }
 }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/UnavailableResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/UnavailableResult.java
@@ -41,7 +41,7 @@ public class UnavailableResult extends ErrorResult {
   private final int alive;
 
   public UnavailableResult(ConsistencyLevel cl, int required, int alive) {
-    this("Cannot achieve consistency level " + cl, cl, required, alive, 0, false);
+    this("Cannot achieve consistency level " + cl, cl, required, alive, 0, null);
   }
 
   @JsonCreator
@@ -51,7 +51,7 @@ public class UnavailableResult extends ErrorResult {
       @JsonProperty(value = "required", required = true) int required,
       @JsonProperty(value = "alive", required = true) int alive,
       @JsonProperty("delay_in_ms") long delayInMs,
-      @JsonProperty("ignore_on_prepare") boolean ignoreOnPrepare) {
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
     super(UNAVAILABLE, errorMessage, delayInMs, ignoreOnPrepare);
     this.cl = cl;
     this.required = required;

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/UnpreparedResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/UnpreparedResult.java
@@ -23,14 +23,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class UnpreparedResult extends ErrorResult {
 
   public UnpreparedResult(String errorMessage) {
-    this(errorMessage, 0, false);
+    this(errorMessage, 0, null);
   }
 
   @JsonCreator
   public UnpreparedResult(
       @JsonProperty(value = "message", required = true) String errorMessage,
       @JsonProperty("delay_in_ms") long delayInMs,
-      @JsonProperty("ignore_on_prepare") boolean ignoreOnPrepare) {
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
     super(UNPREPARED, errorMessage, delayInMs, ignoreOnPrepare);
   }
 }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/VoidResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/VoidResult.java
@@ -30,12 +30,14 @@ public class VoidResult extends Result {
   private List<Action> actions;
 
   public VoidResult() {
-    this(0);
+    this(0, null);
   }
 
   @JsonCreator
-  public VoidResult(@JsonProperty("delay_in_ms") long delayInMs) {
-    super(delayInMs);
+  public VoidResult(
+      @JsonProperty("delay_in_ms") long delayInMs,
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
+    super(delayInMs, ignoreOnPrepare);
     updateActions();
   }
 

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/WriteFailureResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/WriteFailureResult.java
@@ -38,7 +38,7 @@ public class WriteFailureResult extends RequestFailureResult {
       int blockFor,
       Map<InetAddress, RequestFailureReason> failureReasonByEndpoint,
       WriteType writeType) {
-    this(cl, received, blockFor, failureReasonByEndpoint, writeType, 0, false);
+    this(cl, received, blockFor, failureReasonByEndpoint, writeType, 0, null);
   }
 
   @JsonCreator
@@ -50,7 +50,7 @@ public class WriteFailureResult extends RequestFailureResult {
           Map<InetAddress, RequestFailureReason> failureReasonByEndpoint,
       @JsonProperty(value = "write_type", required = true) WriteType writeType,
       @JsonProperty("delay_in_ms") long delayInMs,
-      @JsonProperty("ignore_on_prepare") boolean ignoreOnPrepare) {
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
     super(
         WRITE_FAILURE, cl, received, blockFor, failureReasonByEndpoint, delayInMs, ignoreOnPrepare);
     this.writeType = writeType;

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/WriteTimeoutResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/WriteTimeoutResult.java
@@ -30,7 +30,7 @@ public class WriteTimeoutResult extends RequestTimeoutResult {
   private final WriteType writeType;
 
   public WriteTimeoutResult(ConsistencyLevel cl, int received, int blockFor, WriteType writeType) {
-    this(cl, received, blockFor, writeType, 0, false);
+    this(cl, received, blockFor, writeType, 0, null);
   }
 
   @JsonCreator
@@ -40,7 +40,7 @@ public class WriteTimeoutResult extends RequestTimeoutResult {
       @JsonProperty(value = "block_for", required = true) int blockFor,
       @JsonProperty(value = "write_type", required = true) WriteType writeType,
       @JsonProperty("delay_in_ms") long delayInMs,
-      @JsonProperty("ignore_on_prepare") boolean ignoreOnPrepare) {
+      @JsonProperty("ignore_on_prepare") Boolean ignoreOnPrepare) {
     super(WRITE_TIMEOUT, cl, received, blockFor, delayInMs, ignoreOnPrepare);
     this.writeType = writeType;
   }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/Prime.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/Prime.java
@@ -106,7 +106,7 @@ public class Prime extends StubMapping {
         if (primedRequest.then instanceof SuccessResult) {
           return this.toPreparedAction();
         } else if (primedRequest.then instanceof ErrorResult) {
-          if (((ErrorResult) primedRequest.then).isignoreOnPrepare()) {
+          if (((ErrorResult) primedRequest.then).isIgnoreOnPrepare()) {
             return Collections.emptyList();
           }
         }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/Prime.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/Prime.java
@@ -103,13 +103,14 @@ public class Prime extends StubMapping {
   public List<Action> getActions(AbstractNode node, Frame frame) {
     if (frame.message instanceof Prepare) {
       if (primedRequest.when instanceof Query) {
-        if (primedRequest.then instanceof SuccessResult
-            || (primedRequest.then instanceof ErrorResult
-                && ((ErrorResult) primedRequest.then).isignoreOnPrepare())) {
+        if (primedRequest.then instanceof SuccessResult) {
           return this.toPreparedAction();
+        } else if (primedRequest.then instanceof ErrorResult) {
+          if (((ErrorResult) primedRequest.then).isignoreOnPrepare()) {
+            return Collections.emptyList();
+          }
         }
       }
-      return Collections.emptyList();
     }
     return primedRequest.then.toActions(node, frame);
   }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/Prime.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/Prime.java
@@ -109,6 +109,7 @@ public class Prime extends StubMapping {
           return this.toPreparedAction();
         }
       }
+      return Collections.emptyList();
     }
     return primedRequest.then.toActions(node, frame);
   }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/Prime.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/Prime.java
@@ -93,9 +93,9 @@ public class Prime extends StubMapping {
     return null;
   }
 
-  public List<Action> toPreparedAction() {
+  List<Action> toPreparedAction(long delayInMs) {
     Prepared preparedResponse = toPrepared();
-    MessageResponseAction action = new MessageResponseAction(preparedResponse);
+    MessageResponseAction action = new MessageResponseAction(preparedResponse, delayInMs);
     return Collections.singletonList(action);
   }
 
@@ -104,9 +104,13 @@ public class Prime extends StubMapping {
     if (frame.message instanceof Prepare) {
       if (primedRequest.when instanceof Query) {
         if (primedRequest.then instanceof SuccessResult) {
-          return this.toPreparedAction();
+          // Apply delay if not ignore on prepare.
+          long delayInMs =
+              !primedRequest.then.isIgnoreOnPrepare() ? primedRequest.then.getDelayInMs() : 0;
+          return this.toPreparedAction(delayInMs);
         } else if (primedRequest.then instanceof ErrorResult) {
-          if (((ErrorResult) primedRequest.then).isIgnoreOnPrepare()) {
+          // If ignore on prepare, delegate.
+          if (primedRequest.then.isIgnoreOnPrepare()) {
             return Collections.emptyList();
           }
         }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/PrimeDsl.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/PrimeDsl.java
@@ -217,7 +217,7 @@ public class PrimeDsl {
    */
   public static CloseConnectionResult closeConnection(
       DisconnectAction.Scope scope, CloseType closeType) {
-    return new CloseConnectionResult(scope, closeType, 0);
+    return new CloseConnectionResult(scope, closeType);
   }
 
   /**
@@ -448,11 +448,46 @@ public class PrimeDsl {
       return this;
     }
 
+    /**
+     * Adds a delay to the prime.
+     *
+     * @param delay How long to delay
+     * @param delayUnit The unit of the delay
+     * @return this builder
+     */
     public PrimeBuilder delay(long delay, TimeUnit delayUnit) {
       if (then == null) {
         throw new RuntimeException("then must be called before delay.");
       }
       then.setDelay(delay, delayUnit);
+      return this;
+    }
+
+    /**
+     * Indicates that the prime should not apply to a matched prepare message. This is the default
+     * behavior so this method doesn't need to be used unless you want your code to be more
+     * explicit.
+     *
+     * @return this builder
+     */
+    public PrimeBuilder ignoreOnPrepare() {
+      if (then == null) {
+        throw new RuntimeException("then must be called before ignoreOnPrepare.");
+      }
+      then.setIgnoreOnPrepare(true);
+      return this;
+    }
+
+    /**
+     * Indicates that the prime should apply to a matched prepare message.
+     *
+     * @return this builder
+     */
+    public PrimeBuilder applyToPrepare() {
+      if (then == null) {
+        throw new RuntimeException("then must be called before applyToPrepare.");
+      }
+      then.setIgnoreOnPrepare(false);
       return this;
     }
 

--- a/common/src/test/java/com/datastax/oss/simulacron/common/cluster/ObjectMapperHolderTest.java
+++ b/common/src/test/java/com/datastax/oss/simulacron/common/cluster/ObjectMapperHolderTest.java
@@ -104,7 +104,7 @@ public class ObjectMapperHolderTest {
     String json = mapper.writeValueAsString(requestPrime);
 
     String expectedJson =
-        "{\"when\":{\"request\":\"query\",\"query\":\"SELECT * table_name\"},\"then\":{\"result\":\"success\",\"rows\":[{\"column1\":\"column1\",\"column2\":\"2\"}],\"column_types\":{\"column1\":\"ascii\",\"column2\":\"bigint\"},\"delay_in_ms\":0}}";
+        "{\"when\":{\"request\":\"query\",\"query\":\"SELECT * table_name\"},\"then\":{\"result\":\"success\",\"rows\":[{\"column1\":\"column1\",\"column2\":\"2\"}],\"column_types\":{\"column1\":\"ascii\",\"column2\":\"bigint\"},\"delay_in_ms\":0,\"ignore_on_prepare\":true}}";
 
     assertThat(json).isEqualTo(expectedJson);
 
@@ -156,12 +156,13 @@ public class ObjectMapperHolderTest {
   public void testPrimeOptions() throws Exception {
     Options when = Options.INSTANCE;
     Result then = new NoResult();
+    then.setIgnoreOnPrepare(false);
     RequestPrime requestPrime = new RequestPrime(when, then);
 
     String json = mapper.writeValueAsString(requestPrime);
 
     String expectedJson =
-        "{\"when\":{\"request\":\"options\"},\"then\":{\"result\":\"no_result\",\"delay_in_ms\":0}}";
+        "{\"when\":{\"request\":\"options\"},\"then\":{\"result\":\"no_result\",\"delay_in_ms\":0,\"ignore_on_prepare\":false}}";
 
     assertThat(json).isEqualTo(expectedJson);
 

--- a/http-server/src/main/resources/webroot/swagger/swagger.yaml
+++ b/http-server/src/main/resources/webroot/swagger/swagger.yaml
@@ -2001,7 +2001,14 @@ definitions:
         example: success
       delay_in_ms:
         type: integer
+        description: Adds delay to send response back to client.
         example: 0
+      ignore_on_prepare:
+        type: boolean
+        description: >
+          Whether or not this result be applied to a matching prepare statement.  If not specified,
+          defaults to true (does not apply) and applies to the execution of statements tied to that
+          prepared statement.
   Row:
     type: object
     description: |
@@ -2048,10 +2055,6 @@ definitions:
       - type: object
         required:
           - ignore_on_prepare
-        properties:
-          ignore_on_prepare:
-            type: boolean
-            example: false
   SuccessResultBatch:
     allOf:
       - $ref: '#/definitions/Then'

--- a/http-server/src/test/java/com/datastax/oss/simulacron/http/server/HttpPrimeQueryIntegrationTest.java
+++ b/http-server/src/test/java/com/datastax/oss/simulacron/http/server/HttpPrimeQueryIntegrationTest.java
@@ -233,14 +233,32 @@ public class HttpPrimeQueryIntegrationTest {
     HashMap<String, Object> params = new HashMap<>();
     params.put("c1", "c1");
     RequestPrime prime =
-            HttpTestUtil.createPrimedErrorOnQuery(
-                    "SELECT table_ignore FROM foo WHERE c1=?", params, paramTypes);
+        HttpTestUtil.createPrimedErrorOnQuery(
+            "SELECT table_ignore FROM foo WHERE c1=?", params, paramTypes, true);
     HttpTestResponse response = server.prime(prime);
     assertNotNull(response);
     RequestPrime responseQuery = om.readValue(response.body, RequestPrime.class);
     assertThat(responseQuery).isEqualTo(prime);
     String contactPoint = HttpTestUtil.getContactPointString(server.getCluster(), 0);
     HttpTestUtil.makeNativeBoundQueryWithPositionalParamExpectingError(
-                    "SELECT table_ignore FROM foo WHERE c1=?", contactPoint, "c1");
+        "SELECT table_ignore FROM foo WHERE c1=?", contactPoint, "c1", false);
+  }
+
+  @Test
+  public void testErrorOnPreparedStatement() throws Exception {
+    HashMap<String, String> paramTypes = new HashMap<>();
+    paramTypes.put("c1", "ascii");
+    HashMap<String, Object> params = new HashMap<>();
+    params.put("c1", "c1");
+    RequestPrime prime =
+        HttpTestUtil.createPrimedErrorOnQuery(
+            "SELECT table_ignore FROM foo WHERE c1=?", params, paramTypes, false);
+    HttpTestResponse response = server.prime(prime);
+    assertNotNull(response);
+    RequestPrime responseQuery = om.readValue(response.body, RequestPrime.class);
+    assertThat(responseQuery).isEqualTo(prime);
+    String contactPoint = HttpTestUtil.getContactPointString(server.getCluster(), 0);
+    HttpTestUtil.makeNativeBoundQueryWithPositionalParamExpectingError(
+        "SELECT table_ignore FROM foo WHERE c1=?", contactPoint, "c1", true);
   }
 }

--- a/http-server/src/test/java/com/datastax/oss/simulacron/http/server/HttpPrimeQueryIntegrationTest.java
+++ b/http-server/src/test/java/com/datastax/oss/simulacron/http/server/HttpPrimeQueryIntegrationTest.java
@@ -225,4 +225,22 @@ public class HttpPrimeQueryIntegrationTest {
             "SELECT * FROM users2 WHERE id = :id and id2 = :id2", contactPoint, values2);
     assertThat(set.all().size()).isEqualTo(0);
   }
+
+  @Test
+  public void testErrorOnBoundStatement() throws Exception {
+    HashMap<String, String> paramTypes = new HashMap<>();
+    paramTypes.put("c1", "ascii");
+    HashMap<String, Object> params = new HashMap<>();
+    params.put("c1", "c1");
+    RequestPrime prime =
+            HttpTestUtil.createPrimedErrorOnQuery(
+                    "SELECT table_ignore FROM foo WHERE c1=?", params, paramTypes);
+    HttpTestResponse response = server.prime(prime);
+    assertNotNull(response);
+    RequestPrime responseQuery = om.readValue(response.body, RequestPrime.class);
+    assertThat(responseQuery).isEqualTo(prime);
+    String contactPoint = HttpTestUtil.getContactPointString(server.getCluster(), 0);
+    HttpTestUtil.makeNativeBoundQueryWithPositionalParamExpectingError(
+                    "SELECT table_ignore FROM foo WHERE c1=?", contactPoint, "c1");
+  }
 }

--- a/http-server/src/test/java/com/datastax/oss/simulacron/http/server/HttpTestUtil.java
+++ b/http-server/src/test/java/com/datastax/oss/simulacron/http/server/HttpTestUtil.java
@@ -23,12 +23,17 @@ import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SimpleStatement;
 import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.exceptions.QueryExecutionException;
+import com.datastax.driver.core.exceptions.WriteFailureException;
 import com.datastax.oss.simulacron.common.cluster.NodeSpec;
 import com.datastax.oss.simulacron.common.cluster.RequestPrime;
+import com.datastax.oss.simulacron.common.codec.ConsistencyLevel;
+import com.datastax.oss.simulacron.common.codec.WriteType;
 import com.datastax.oss.simulacron.common.request.Batch;
 import com.datastax.oss.simulacron.common.request.Query;
 import com.datastax.oss.simulacron.common.result.Result;
 import com.datastax.oss.simulacron.common.result.SuccessResult;
+import com.datastax.oss.simulacron.common.result.WriteTimeoutResult;
 import com.datastax.oss.simulacron.server.BoundCluster;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -80,13 +85,30 @@ public class HttpTestUtil {
   }
 
   public static ResultSet makeNativeBoundQueryWithPositionalParam(
-      String query, String contactPoint, Object param) {
+      String query, String contactPoint, Object param){
     com.datastax.driver.core.Cluster cluster =
         defaultBuilder().addContactPoint(contactPoint).build();
     Session session = cluster.connect();
     com.datastax.driver.core.PreparedStatement prepared = session.prepare(query);
     BoundStatement bound = getBoundStatement(query, contactPoint, param);
     return executeQueryWithFreshSession(bound, contactPoint, session, cluster);
+  }
+
+  public static void makeNativeBoundQueryWithPositionalParamExpectingError(
+          String query, String contactPoint, Object param) throws Exception {
+    com.datastax.driver.core.Cluster cluster =
+            defaultBuilder().addContactPoint(contactPoint).build();
+    Session session = cluster.connect();
+    com.datastax.driver.core.PreparedStatement prepared = session.prepare(query);
+
+    BoundStatement bound = getBoundStatement(query, contactPoint, param);
+    try {
+      executeQueryWithFreshSession(bound, contactPoint, session, cluster);
+      throw new Exception("Bound statement should have thrown exception");
+    }
+    catch (QueryExecutionException e) {
+      // An exception should be throw for the bound statement, not the prepared one
+    }
   }
 
   public static BoundStatement getBoundStatement(String query, String contactPoint, Object param) {
@@ -138,6 +160,22 @@ public class HttpTestUtil {
     column_types.put("column1", "ascii");
     column_types.put("column2", "bigint");
     Result then = new SuccessResult(rows, column_types);
+    RequestPrime requestPrime = new RequestPrime(when, then);
+    return requestPrime;
+  }
+
+  public static RequestPrime createPrimedErrorOnQuery(
+          String query, HashMap<String, Object> params, HashMap<String, String> paramTypes) {
+    Query when = new Query(query, Collections.emptyList(), params, paramTypes);
+    List<Map<String, Object>> rows = new ArrayList<Map<String, Object>>();
+    HashMap row1 = new HashMap<String, String>();
+    row1.put("column1", "column1");
+    row1.put("column2", "2");
+    rows.add(row1);
+    Map<String, String> column_types = new HashMap<String, String>();
+    column_types.put("column1", "ascii");
+    column_types.put("column2", "bigint");
+    Result then = new WriteTimeoutResult(ConsistencyLevel.ALL, 2, 1, WriteType.SIMPLE, 0, false);
     RequestPrime requestPrime = new RequestPrime(when, then);
     return requestPrime;
   }


### PR DESCRIPTION
When I wanted an exception to happen on the bound statement (I think this is what happens by default) it was happening on the prepared statement, this is changed by the first commit.

I'm not sure of the use of `ignore_on_prepare`, but I think it should be used to determine if the action should be on the prepared statement or on the bound statement. I'm not sure about this part so I've done in the second commit.

I can squash them if we want to merge both of them.

Fixes #23