### PR TITLE
[#10], [#22] Configurable Protocol Versions and V5 support

### DIFF
--- a/common/src/main/java/com/datastax/oss/simulacron/common/cluster/AbstractCluster.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/cluster/AbstractCluster.java
@@ -27,8 +27,9 @@ import java.util.stream.Collectors;
 public abstract class AbstractCluster<D extends AbstractDataCenter<?, N>, N extends AbstractNode>
     extends AbstractNodeProperties implements ClusterStructure<D, N> {
 
-  // json managed reference is used to indicate a two way linking between the 'parent' (cluster) and 'children'
-  // (datacenters) in a json tree.  This tells the jackson mapping to tie child DCs to this cluster on deserialization.
+  // json managed reference is used to indicate a two way linking between the 'parent' (cluster) and
+  // 'children' (datacenters) in a json tree.  This tells the jackson mapping to tie child DCs to
+  // this cluster on deserialization.
   @JsonManagedReference
   @JsonProperty("data_centers")
   private final Collection<D> dataCenters = new ConcurrentSkipListSet<>();

--- a/common/src/main/java/com/datastax/oss/simulacron/common/cluster/AbstractDataCenter.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/cluster/AbstractDataCenter.java
@@ -26,11 +26,13 @@ import java.util.stream.Collectors;
 public abstract class AbstractDataCenter<C extends AbstractCluster, N extends AbstractNode>
     extends AbstractNodeProperties implements DataCenterStructure<C, N> {
 
-  // json managed reference is used to indicate a two way linking between the 'parent' (datacenter) and 'children'
-  // (nodes) in a json tree.  This tells the jackson mapping to tie child nodes to this dc on deserialization.
+  // json managed reference is used to indicate a two way linking between the 'parent' (datacenter)
+  // and 'children' (nodes) in a json tree.  This tells the jackson mapping to tie child nodes to
+  // this dc on deserialization.
   @JsonManagedReference private final Collection<N> nodes = new ConcurrentSkipListSet<>();
 
-  // back reference is used to indicate the parent of this node while deserializing should be tied to this field.
+  // back reference is used to indicate the parent of this node while deserializing should be tied
+  // to this field.
   @JsonBackReference private final C parent;
 
   @SuppressWarnings("unchecked")

--- a/common/src/main/java/com/datastax/oss/simulacron/common/cluster/AbstractNode.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/cluster/AbstractNode.java
@@ -125,8 +125,9 @@ public class AbstractNode<C extends AbstractCluster, D extends AbstractDataCente
 
   @Override
   public Long getActiveConnections() {
-    // In the case of a concrete 'NodeSpec' instance, active connections will always be 0 since there is no actual
-    // connection state here.  We expect specialized implementations of NodeSpec to override this.
+    // In the case of a concrete 'NodeSpec' instance, active connections will always be 0 since
+    // there is no actual connection state here.  We expect specialized implementations of NodeSpec
+    // to override this.
     return 0L;
   }
 }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/cluster/Identifiable.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/cluster/Identifiable.java
@@ -26,8 +26,9 @@ public interface Identifiable extends Comparable<Identifiable> {
 
   @Override
   default int compareTo(Identifiable other) {
-    // by default compare by id, this is not perfect if comparing cross-dc or comparing different types but in the
-    // general case this should only be used for comparing for things in same group.
+    // by default compare by id, this is not perfect if comparing cross-dc or comparing different
+    // types but in the general case this should only be used for comparing for things in same
+    // group.
     return (int) (this.getId() - other.getId());
   }
 }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/cluster/ObjectMapperHolder.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/cluster/ObjectMapperHolder.java
@@ -93,8 +93,8 @@ public class ObjectMapperHolder {
     @Override
     public void serialize(InetAddress value, JsonGenerator gen, SerializerProvider serializers)
         throws IOException {
-      // Adapted from com.fasterxml.jackson.databind.ser.std.InetAddressSerializer but writes field name instead
-      // of string.
+      // Adapted from com.fasterxml.jackson.databind.ser.std.InetAddressSerializer but writes field
+      // name instead of string.
       // Ok: get textual description; choose "more specific" part
       String str = value.toString().trim();
       int ix = str.indexOf('/');

--- a/common/src/main/java/com/datastax/oss/simulacron/common/codec/RawTypeParser.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/codec/RawTypeParser.java
@@ -211,8 +211,8 @@ class RawTypeParser {
       if (isEOS()) throw new InvalidTypeException("Non closed angle brackets");
 
       // Only parse for '<' and '>' characters if not within a quoted identifier.
-      // Note we don't need to handle escaped quotes ("") in type names here, because they just cause inQuotes to flip
-      // to false and immediately back to true
+      // Note we don't need to handle escaped quotes ("") in type names here, because they just
+      // cause inQuotes to flip to false and immediately back to true
       if (!inQuotes) {
         if (str.charAt(idx) == '"') {
           inQuotes = true;

--- a/common/src/main/java/com/datastax/oss/simulacron/common/request/Batch.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/request/Batch.java
@@ -53,7 +53,7 @@ public final class Batch extends Request {
           (com.datastax.oss.protocol.internal.request.Batch) frame.message;
 
       ConsistencyLevel level = ConsistencyLevel.fromCode(batch.consistency);
-      //NOTE: Absent CL level means it will match all CL levels
+      // NOTE: Absent CL level means it will match all CL levels
       if (this.consistencyEnum.contains(level) || this.consistencyEnum.size() == 0) {
 
         if (batch.values.size() != queries.size()) {

--- a/common/src/main/java/com/datastax/oss/simulacron/common/request/Query.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/request/Query.java
@@ -95,14 +95,14 @@ public final class Query extends Request {
       }
     }
     if (frame.message instanceof com.datastax.oss.protocol.internal.request.Query) {
-      //If the query expected matches the primed query example and CL levels match. Return true;
+      // If the query expected matches the primed query example and CL levels match. Return true;
       com.datastax.oss.protocol.internal.request.Query query =
           (com.datastax.oss.protocol.internal.request.Query) frame.message;
       if (this.query.equals(query.query)) {
         ConsistencyLevel level = ConsistencyLevel.fromCode(query.options.consistency);
-        //NOTE: Absent CL level means it will match all CL levels
+        // NOTE: Absent CL level means it will match all CL levels
         if (this.consistencyEnum.contains(level) || this.consistencyEnum.size() == 0) {
-          //Id any parameters are present we must make sure they match those in the primed queries
+          // Id any parameters are present we must make sure they match those in the primed queries
           return checkParamsMatch(query.options, frame);
         }
       }
@@ -152,7 +152,7 @@ public final class Query extends Request {
         if (options.namedValues.size() != params.size()) {
           return false;
         }
-        //look up each parameter and make sure they match
+        // look up each parameter and make sure they match
         for (String key : options.namedValues.keySet()) {
           String stringType = paramTypes.get(key);
 

--- a/common/src/main/java/com/datastax/oss/simulacron/common/result/SuccessResult.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/result/SuccessResult.java
@@ -69,7 +69,8 @@ public class SuccessResult extends Result {
   @Override
   public List<Action> toActions(AbstractNode node, Frame frame) {
     CqlMapper mapper = CqlMapper.forVersion(frame.protocolVersion);
-    //This will return all the rows specified in the query, along with any corresponding metadata about the row
+    // This will return all the rows specified in the query, along with any corresponding metadata
+    // about the row
     boolean meta_constructed = false;
     List<ColumnSpec> columnMetadata = new LinkedList<ColumnSpec>();
     Queue<List<ByteBuffer>> rows = new LinkedList<List<ByteBuffer>>();
@@ -77,7 +78,7 @@ public class SuccessResult extends Result {
     for (Map<String, Object> row : this.rows) {
       List<ByteBuffer> rowByteBuffer = new LinkedList<ByteBuffer>();
       CodecUtils.ColumnSpecBuilder columnBuilder = CodecUtils.columnSpecBuilder();
-      //Iterate over all the rows and create column meta data if needed
+      // Iterate over all the rows and create column meta data if needed
       for (String key : row.keySet()) {
         RawType type = CodecUtils.getTypeFromName(columnTypes.get(key));
         if (!meta_constructed) {

--- a/common/src/test/java/com/datastax/oss/simulacron/common/cluster/ClusterSpecTest.java
+++ b/common/src/test/java/com/datastax/oss/simulacron/common/cluster/ClusterSpecTest.java
@@ -82,7 +82,8 @@ public class ClusterSpecTest {
 
   @Test
   public void testDefaultConstructor() {
-    // This is only used by jackson mapper, but ensure it has sane defaults and doesn't throw any exceptions.
+    // This is only used by jackson mapper, but ensure it has sane defaults and doesn't throw any
+    // exceptions.
     ClusterSpec cluster = new ClusterSpec();
     assertThat(cluster.getParent()).isEmpty();
     assertThat(cluster.getId()).isEqualTo(null);

--- a/common/src/test/java/com/datastax/oss/simulacron/common/cluster/DataCenterSpecTest.java
+++ b/common/src/test/java/com/datastax/oss/simulacron/common/cluster/DataCenterSpecTest.java
@@ -77,7 +77,8 @@ public class DataCenterSpecTest {
 
   @Test
   public void testDefaultConstructor() {
-    // This is only used by jackson mapper, but ensure it has sane defaults and doesn't throw any exceptions.
+    // This is only used by jackson mapper, but ensure it has sane defaults and doesn't throw any
+    // exceptions.
     DataCenterSpec dc = new DataCenterSpec();
     assertThat(dc.getCluster()).isNull();
     assertThat(dc.getParent()).isEmpty();

--- a/common/src/test/java/com/datastax/oss/simulacron/common/cluster/NodeTest.java
+++ b/common/src/test/java/com/datastax/oss/simulacron/common/cluster/NodeTest.java
@@ -75,7 +75,8 @@ public class NodeTest {
 
   @Test
   public void testDefaultConstructor() {
-    // This is only used by jackson mapper, but ensure it has sane defaults and doesn't throw any exceptions.
+    // This is only used by jackson mapper, but ensure it has sane defaults and doesn't throw any
+    // exceptions.
     NodeSpec node = new NodeSpec();
     assertThat(node.getDataCenter()).isNull();
     assertThat(node.getCluster()).isNull();

--- a/common/src/test/java/com/datastax/oss/simulacron/common/codec/CqlMapperTest.java
+++ b/common/src/test/java/com/datastax/oss/simulacron/common/codec/CqlMapperTest.java
@@ -639,7 +639,8 @@ public class CqlMapperTest {
     }
 
     // Values of map should be mapped using encodeObject
-    // In this case we have a codec that calls for map<ascii, int> but we give it a Map<Integer, String>
+    // In this case we have a codec that calls for map<ascii, int> but we give it a Map<Integer,
+    // String>
     // The codec should properly convert to Map<String, Integer> when encoding.
     Map<Integer, String> swapMap1 = new HashMap<>();
     swapMap1.put(0, "1");

--- a/common/src/test/java/com/datastax/oss/simulacron/common/request/QueryTest.java
+++ b/common/src/test/java/com/datastax/oss/simulacron/common/request/QueryTest.java
@@ -33,8 +33,8 @@ public class QueryTest {
 
   @Test
   public void shouldAlwaysMatchWhenParamValuesAreNotSet() {
-    // Ensures that if a query prime is set up where there are no param values configured that it matches every
-    // query matching the query text.
+    // Ensures that if a query prime is set up where there are no param values configured that it
+    // matches every query matching the query text.
     String queryStr = "update x set y = ?, z = ?, a = ? where b = ?";
     Map<String, String> paramTypes = new HashMap<>();
     paramTypes.put("y", "int");

--- a/common/src/test/java/com/datastax/oss/simulacron/common/stubbing/PeerMetadataHandlerTest.java
+++ b/common/src/test/java/com/datastax/oss/simulacron/common/stubbing/PeerMetadataHandlerTest.java
@@ -261,7 +261,8 @@ public class PeerMetadataHandlerTest {
 
   @Test
   public void shouldHandleQueryAllPeersDSE() {
-    // querying for peers should return a row for each other node in the cluster and return DSE columns
+    // querying for peers should return a row for each other node in the cluster and return DSE
+    // columns
     List<Action> node0Actions =
         handler.getActions(dseNode0, queryFrame("SELECT * FROM system.peers"));
 
@@ -301,7 +302,8 @@ public class PeerMetadataHandlerTest {
 
   @Test
   public void shouldHandleQuerySpecificPeerNamedParameter() throws UnknownHostException {
-    // when peer query is made for a peer in the cluster using named parameters, we should get 1 row back.
+    // when peer query is made for a peer in the cluster using named parameters, we should get 1 row
+    // back.
     InetAddress addr = InetAddress.getByAddress(new byte[] {127, 0, 11, 17});
     Map<String, ByteBuffer> params = new HashMap<>();
     params.put("address", ByteBuffer.wrap(addr.getAddress()));

--- a/driver-3x/src/test/java/com/datastax/oss/simulacron/driver/PeerMetadataIntegrationTest.java
+++ b/driver-3x/src/test/java/com/datastax/oss/simulacron/driver/PeerMetadataIntegrationTest.java
@@ -70,7 +70,8 @@ public class PeerMetadataIntegrationTest {
 
   @Test
   public void testVnodeSupport() throws Exception {
-    // Validate that peers as appropriately discovered when connecting to a node and vnodes are assigned.
+    // Validate that peers as appropriately discovered when connecting to a node and vnodes are
+    // assigned.
     try (BoundCluster boundCluster =
             server.register(ClusterSpec.builder().withNumberOfTokens(256).withNodes(3, 3, 3));
         Cluster driverCluster = defaultBuilder(boundCluster).build()) {

--- a/http-server/src/main/java/com/datastax/oss/simulacron/http/server/ClusterManager.java
+++ b/http-server/src/main/java/com/datastax/oss/simulacron/http/server/ClusterManager.java
@@ -76,7 +76,7 @@ public class ClusterManager implements HttpListener {
                 String name = context.request().getParam("name");
                 StringBuilder response = new StringBuilder();
                 ClusterSpec cluster = null;
-                //General parameters were provided for us.
+                // General parameters were provided for us.
                 if (dcRawString != null) {
                   String[] dcStrs = dcRawString.split(",");
                   int[] dcs = new int[dcStrs.length];
@@ -92,7 +92,7 @@ public class ClusterManager implements HttpListener {
                             .build();
                   }
                 } else {
-                  //A specific cluster object was provided.
+                  // A specific cluster object was provided.
                   // We could add special handling here, but I'm not sure it's worth it
                   String jsonBody = totalBuffer.toString();
                   cluster = om.readValue(jsonBody, ClusterSpec.class);

--- a/http-server/src/main/java/com/datastax/oss/simulacron/http/server/QueryManager.java
+++ b/http-server/src/main/java/com/datastax/oss/simulacron/http/server/QueryManager.java
@@ -167,7 +167,7 @@ public class QueryManager implements HttpListener {
         .route(HttpMethod.POST, "/prime/:clusterIdOrName/:datacenterIdOrName/:nodeIdOrName")
         .handler(this::primeQuery);
 
-    //Deleting primed queries
+    // Deleting primed queries
     router.route(HttpMethod.DELETE, "/prime/:clusterIdOrName").handler(this::clearPrimedQueries);
     router
         .route(HttpMethod.DELETE, "/prime/:clusterIdOrName/:datacenterIdOrName")

--- a/http-server/src/main/resources/webroot/swagger/swagger.yaml
+++ b/http-server/src/main/resources/webroot/swagger/swagger.yaml
@@ -1839,6 +1839,13 @@ definitions:
       graph:
         type: boolean
         example: false
+      protocol_versions:
+        type: list
+        example:
+          - 3
+          - 4
+          - 5
+        description: Protocol versions to support, if not supplied, supported versions are based on cassandra version.
   Node:
     type: object
     required:

--- a/http-server/src/test/java/com/datastax/oss/simulacron/http/server/ActivityLogIntegrationTest.java
+++ b/http-server/src/test/java/com/datastax/oss/simulacron/http/server/ActivityLogIntegrationTest.java
@@ -89,33 +89,33 @@ public class ActivityLogIntegrationTest {
     String[] queries =
         new String[] {"select * from table1", "select * from table2", "select * from table3"};
     primeAndExecuteQueries(primedQueries, queries);
-    //verify for cluster level filter: primed
+    // verify for cluster level filter: primed
     ClusterQueryLogReport queryLogReport =
         server.getLogs(server.getCluster().resolveId() + "?filter=primed");
     List<QueryLog> queryLogs = getAllQueryLogs(queryLogReport);
     assertThat(queryLogs).hasSize(2);
 
-    //verify for cluster level filter: nonprimed
+    // verify for cluster level filter: nonprimed
     queryLogs =
         getAllQueryLogs(server.getLogs(server.getCluster().resolveId() + "?filter=nonprimed"));
     assertThat(queryLogs).hasSize(1);
 
-    //verify for datacenter level filter: primed
+    // verify for datacenter level filter: primed
     queryLogs =
         getAllQueryLogs(server.getLogs(server.getCluster().resolveId() + "/dc1?filter=primed"));
     assertThat(queryLogs).hasSize(2);
 
-    //verify for datacenter level filter: nonprimed
+    // verify for datacenter level filter: nonprimed
     queryLogs =
         getAllQueryLogs(server.getLogs(server.getCluster().resolveId() + "/dc1?filter=nonprimed"));
     assertThat(queryLogs).hasSize(1);
 
-    //verify for node level filter: primed
+    // verify for node level filter: primed
     queryLogs =
         getAllQueryLogs(server.getLogs(server.getCluster().getName() + "/dc1/0?filter=primed"));
     assertThat(queryLogs).hasSize(1);
 
-    //verify for node level filter: nonprimed
+    // verify for node level filter: nonprimed
     queryLogs =
         getAllQueryLogs(server.getLogs(server.getCluster().getName() + "/dc1/0?filter=nonprimed"));
     assertThat(queryLogs).hasSize(0);
@@ -127,12 +127,12 @@ public class ActivityLogIntegrationTest {
 
     try (com.datastax.driver.core.Cluster driverCluster =
         defaultBuilder(server.getCluster())
-            .allowBetaProtocolVersion()
             .withRetryPolicy(FallthroughRetryPolicy.INSTANCE)
             .build()) {
       driverCluster.init();
     }
-    //verify for node level filter: primed.  This should be empty as no primed queries were made other than internal.
+    // verify for node level filter: primed.  This should be empty as no primed queries were made
+    // other than internal.
     List<QueryLog> queryLogs =
         getAllQueryLogs(server.getLogs(server.getCluster().getName() + "?filter=primed"));
     assertThat(queryLogs).isEmpty();
@@ -227,7 +227,6 @@ public class ActivityLogIntegrationTest {
         com.datastax.driver.core.Cluster.builder()
             .addContactPointsWithPorts(cluster.node(0).inetSocketAddress())
             .withNettyOptions(SimulacronDriverSupport.nonQuietClusterCloseOptions)
-            .allowBetaProtocolVersion()
             .withRetryPolicy(FallthroughRetryPolicy.INSTANCE)
             .build()) {
       driverCluster.connect().execute(statement);

--- a/http-server/src/test/java/com/datastax/oss/simulacron/http/server/EndpointIntegrationTest.java
+++ b/http-server/src/test/java/com/datastax/oss/simulacron/http/server/EndpointIntegrationTest.java
@@ -236,7 +236,7 @@ public class EndpointIntegrationTest {
     driverCluster.init();
     driverCluster.close();
 
-    //Second try
+    // Second try
     driverCluster =
         defaultBuilder().addContactPointsWithPorts((InetSocketAddress) node.getAddress()).build();
     driverCluster.init();

--- a/http-server/src/test/java/com/datastax/oss/simulacron/http/server/HttpContainerIntegrationTest.java
+++ b/http-server/src/test/java/com/datastax/oss/simulacron/http/server/HttpContainerIntegrationTest.java
@@ -122,13 +122,13 @@ public class HttpContainerIntegrationTest {
     try {
       HttpTestResponse responseToValidate = future.get();
       ObjectMapper om = ObjectMapperHolder.getMapper();
-      //create cluster object from json return code
+      // create cluster object from json return code
       ClusterSpec cluster = om.readValue(responseToValidate.body, ClusterSpec.class);
       assertThat(responseToValidate.response.statusCode()).isEqualTo(201);
       assertThat(new Long(0)).isEqualTo(cluster.getId());
       assertThat("0").isEqualTo(cluster.getName());
       assertThat(cluster.getPeerInfo()).isEmpty();
-      //create cluster object from json return code
+      // create cluster object from json return code
       Collection<DataCenterSpec> centers = cluster.getDataCenters();
       assertThat(centers.size()).isEqualTo(1);
       DataCenterSpec center = centers.iterator().next();
@@ -169,7 +169,7 @@ public class HttpContainerIntegrationTest {
     HttpTestResponse responseToValidate = future.get();
     validateCluster(responseToValidate, 201);
 
-    //create cluster object from json return code
+    // create cluster object from json return code
     ClusterSpec cluster = om.readValue(responseToValidate.body, ClusterSpec.class);
 
     client = vertx.createHttpClient();
@@ -389,13 +389,13 @@ public class HttpContainerIntegrationTest {
     try {
       HttpTestResponse responseToValidate = future.get();
       ObjectMapper om = ObjectMapperHolder.getMapper();
-      //create cluster object from json return code
+      // create cluster object from json return code
       ClusterSpec cluster = om.readValue(responseToValidate.body, ClusterSpec.class);
       assertThat(responseToValidate.response.statusCode()).isEqualTo(201);
       assertThat(new Long(0)).isEqualTo(cluster.getId());
       assertThat("0").isEqualTo(cluster.getName());
       assertThat(cluster.getPeerInfo()).isEmpty();
-      //create cluster object from json return code
+      // create cluster object from json return code
       Collection<DataCenterSpec> centers = cluster.getDataCenters();
       assertThat(centers.size()).isEqualTo(1);
       DataCenterSpec center = centers.iterator().next();
@@ -446,13 +446,13 @@ public class HttpContainerIntegrationTest {
     try {
       HttpTestResponse responseToValidate = future.get();
       ObjectMapper om = ObjectMapperHolder.getMapper();
-      //create cluster object from json return code
+      // create cluster object from json return code
       ClusterSpec cluster = om.readValue(responseToValidate.body, ClusterSpec.class);
       assertThat(responseToValidate.response.statusCode()).isEqualTo(201);
       assertThat(new Long(0)).isEqualTo(cluster.getId());
       assertThat("0").isEqualTo(cluster.getName());
       assertThat(cluster.getPeerInfo()).isEmpty();
-      //create cluster object from json return code
+      // create cluster object from json return code
       Collection<DataCenterSpec> centers = cluster.getDataCenters();
       assertThat(centers.size()).isEqualTo(3);
       long currentCenterId = 0;
@@ -723,7 +723,7 @@ public class HttpContainerIntegrationTest {
     try {
       HttpTestResponse responseToValidate = future.get();
       ObjectMapper om = ObjectMapperHolder.getMapper();
-      //create cluster object from json return code
+      // create cluster object from json return code
       assertThat(responseToValidate.response.statusCode()).isEqualTo(201);
       ClusterSpec cluster = om.readValue(responseToValidate.body, ClusterSpec.class);
       return cluster;
@@ -754,7 +754,7 @@ public class HttpContainerIntegrationTest {
     try {
       HttpTestResponse responseToValidate = future.get();
       ObjectMapper om = ObjectMapperHolder.getMapper();
-      //create cluster object from json return code
+      // create cluster object from json return code
       assertThat(responseToValidate.response.statusCode()).isEqualTo(201);
       ClusterSpec cluster = om.readValue(responseToValidate.body, ClusterSpec.class);
       return cluster;
@@ -767,13 +767,13 @@ public class HttpContainerIntegrationTest {
   private void validateCluster(HttpTestResponse responseToValidate, int expectedStatusCode)
       throws Exception {
     ObjectMapper om = ObjectMapperHolder.getMapper();
-    //create cluster object from json return code
+    // create cluster object from json return code
     ClusterSpec cluster = om.readValue(responseToValidate.body, ClusterSpec.class);
     assertThat(responseToValidate.response.statusCode()).isEqualTo(expectedStatusCode);
     assertThat(new Long(0)).isEqualTo(cluster.getId());
     assertThat("0").isEqualTo(cluster.getName());
     assertThat(cluster.getPeerInfo()).isEmpty();
-    //create cluster object from json return code
+    // create cluster object from json return code
     Collection<DataCenterSpec> centers = cluster.getDataCenters();
     assertThat(centers.size()).isEqualTo(3);
     for (DataCenterSpec center : centers.toArray(new DataCenterSpec[centers.size()])) {

--- a/native-server/src/main/java/com/datastax/oss/simulacron/server/AddressResolver.java
+++ b/native-server/src/main/java/com/datastax/oss/simulacron/server/AddressResolver.java
@@ -36,10 +36,10 @@ public interface AddressResolver extends Supplier<SocketAddress> {
   byte[] defaultStartingIp = new byte[] {127, 0, 1, 1};
   int defaultStartingPort = 9042;
 
-  // TODO: make this configurable when needed.  For now we'll just use incrementing IPs from 127.0.1.1
-  // but eventually it might be nice to have a resolver that returns incrementing ips + ports when C*
-  // supports multiple instances per IP.  Also might be nice if a user wants to use a different IP range
-  // or run multiple instances.
+  // TODO: make this configurable when needed.  For now we'll just use incrementing IPs from
+  // 127.0.1.1 but eventually it might be nice to have a resolver that returns incrementing ips +
+  // ports when C* supports multiple instances per IP.  Also might be nice if a user wants to use a
+  // different IP range or run multiple instances.
   AddressResolver defaultResolver = new Inet4Resolver();
 
   AddressResolver localAddressResolver = () -> new LocalAddress(UUID.randomUUID().toString());
@@ -66,7 +66,8 @@ public interface AddressResolver extends Supplier<SocketAddress> {
               byte[] o1Bytes = o1.getAddress().getAddress();
               byte[] o2Bytes = o2.getAddress().getAddress();
 
-              // If comparing ipv6 and ipv4 addresses, consider ipv6 greater, this in practice shouldn't happen.
+              // If comparing ipv6 and ipv4 addresses, consider ipv6 greater, this in practice
+              // shouldn't happen.
               if (o1Bytes.length != o2Bytes.length) {
                 return o1Bytes.length - o2Bytes.length;
               }

--- a/native-server/src/main/java/com/datastax/oss/simulacron/server/BoundCluster.java
+++ b/native-server/src/main/java/com/datastax/oss/simulacron/server/BoundCluster.java
@@ -15,6 +15,9 @@
  */
 package com.datastax.oss.simulacron.server;
 
+import static com.datastax.oss.simulacron.server.FrameCodecUtils.buildFrameCodec;
+import static com.datastax.oss.simulacron.server.FrameCodecUtils.defaultFrameCodec;
+
 import com.datastax.oss.protocol.internal.Frame;
 import com.datastax.oss.simulacron.common.cluster.AbstractCluster;
 import com.datastax.oss.simulacron.common.cluster.ClusterConnectionReport;
@@ -49,6 +52,8 @@ public class BoundCluster extends AbstractCluster<BoundDataCenter, BoundNode>
 
   private final transient List<QueryListenerWrapper> queryListeners = new ArrayList<>();
 
+  private final transient FrameCodecWrapper frameCodec;
+
   BoundCluster(ClusterSpec delegate, Long clusterId, Server server) {
     super(
         delegate.getName(),
@@ -58,6 +63,7 @@ public class BoundCluster extends AbstractCluster<BoundDataCenter, BoundNode>
         delegate.getPeerInfo());
     this.server = server;
     this.stubStore = new StubStore();
+    this.frameCodec = buildFrameCodec(delegate).orElse(defaultFrameCodec());
   }
 
   @Override
@@ -159,6 +165,12 @@ public class BoundCluster extends AbstractCluster<BoundDataCenter, BoundNode>
   @Override
   public Server getServer() {
     return server;
+  }
+
+  @Override
+  @JsonIgnore
+  public FrameCodecWrapper getFrameCodec() {
+    return frameCodec;
   }
 
   Optional<StubMapping> find(BoundNode node, Frame frame) {

--- a/native-server/src/main/java/com/datastax/oss/simulacron/server/BoundDataCenter.java
+++ b/native-server/src/main/java/com/datastax/oss/simulacron/server/BoundDataCenter.java
@@ -15,6 +15,8 @@
  */
 package com.datastax.oss.simulacron.server;
 
+import static com.datastax.oss.simulacron.server.FrameCodecUtils.buildFrameCodec;
+
 import com.datastax.oss.protocol.internal.Frame;
 import com.datastax.oss.simulacron.common.cluster.AbstractDataCenter;
 import com.datastax.oss.simulacron.common.cluster.ClusterConnectionReport;
@@ -48,6 +50,8 @@ public class BoundDataCenter extends AbstractDataCenter<BoundCluster, BoundNode>
 
   private final transient List<QueryListenerWrapper> queryListeners = new ArrayList<>();
 
+  private final transient FrameCodecWrapper frameCodec;
+
   BoundDataCenter(BoundCluster parent) {
     super(
         "dummy",
@@ -59,6 +63,7 @@ public class BoundDataCenter extends AbstractDataCenter<BoundCluster, BoundNode>
     this.server = parent.getServer();
     this.cluster = parent;
     this.stubStore = new StubStore();
+    this.frameCodec = parent.getFrameCodec();
   }
 
   BoundDataCenter(DataCenterSpec delegate, BoundCluster parent) {
@@ -72,6 +77,7 @@ public class BoundDataCenter extends AbstractDataCenter<BoundCluster, BoundNode>
     this.server = parent.getServer();
     this.cluster = parent;
     this.stubStore = new StubStore();
+    this.frameCodec = buildFrameCodec(delegate).orElse(parent.getFrameCodec());
   }
 
   @Override
@@ -173,6 +179,12 @@ public class BoundDataCenter extends AbstractDataCenter<BoundCluster, BoundNode>
   @Override
   public Server getServer() {
     return server;
+  }
+
+  @Override
+  @JsonIgnore
+  public FrameCodecWrapper getFrameCodec() {
+    return frameCodec;
   }
 
   Optional<StubMapping> find(BoundNode node, Frame frame) {

--- a/native-server/src/main/java/com/datastax/oss/simulacron/server/BoundTopic.java
+++ b/native-server/src/main/java/com/datastax/oss/simulacron/server/BoundTopic.java
@@ -240,6 +240,9 @@ public interface BoundTopic<C extends ConnectionReport, Q extends QueryLogReport
   @JsonIgnore
   Server getServer();
 
+  @JsonIgnore
+  FrameCodecWrapper getFrameCodec();
+
   @Override
   default void close() {
     try {

--- a/native-server/src/main/java/com/datastax/oss/simulacron/server/FrameCodecUtils.java
+++ b/native-server/src/main/java/com/datastax/oss/simulacron/server/FrameCodecUtils.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.server;
+
+import com.datastax.oss.protocol.internal.FrameCodec;
+import com.datastax.oss.protocol.internal.ProtocolV3ServerCodecs;
+import com.datastax.oss.protocol.internal.ProtocolV4ServerCodecs;
+import com.datastax.oss.protocol.internal.ProtocolV5ServerCodecs;
+import com.datastax.oss.simulacron.common.cluster.NodeProperties;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class FrameCodecUtils {
+
+  private static final Logger logger = LoggerFactory.getLogger(FrameCodecUtils.class);
+  private static final List<Integer> defaultProtocolVersions = new ArrayList<>();
+  private static final String PROTOCOL_VERSIONS = "protocol_versions";
+
+  static {
+    defaultProtocolVersions.add(3);
+    defaultProtocolVersions.add(4);
+  }
+
+  private static final FrameCodecWrapper defaultFrameCodec =
+      new FrameCodecWrapper(
+          new TreeSet<>(defaultProtocolVersions),
+          new ProtocolV3ServerCodecs(),
+          new ProtocolV4ServerCodecs());
+
+  static Optional<FrameCodecWrapper> buildFrameCodec(NodeProperties topic) {
+    // First attempt to parse "protocol_versions" from peer info, if present use those.
+    if (topic.getPeerInfo().containsKey(PROTOCOL_VERSIONS)) {
+      List<Integer> protocolVersions =
+          topic.resolvePeerInfo(PROTOCOL_VERSIONS, defaultProtocolVersions);
+      return Optional.of(buildFrameCodec(new TreeSet<>(protocolVersions)));
+    } else {
+      // Next attempt to resolve protocol versions from configured cassandra version but only do
+      // this if protocol_versions does not resolve at all.
+      if (topic.getCassandraVersion() != null && !topic.isPeerInfoPresent(PROTOCOL_VERSIONS)) {
+        if (topic.getCassandraVersion().startsWith("4.")) {
+          return Optional.of(buildFrameCodec(3, 4, 5));
+        } else if (topic.getCassandraVersion().startsWith("2.2")) {
+          return Optional.of(buildFrameCodec(3, 4));
+        } else if (topic.getCassandraVersion().startsWith("2.1")) {
+          return Optional.of(buildFrameCodec(3));
+        } else {
+          logger.warn(
+              "Could not resolve supported protocol versions from cassandra version "
+                  + topic.getCassandraVersion());
+        }
+      }
+      // If can't be resolved, return empty, caller will likely defer to parent or use
+      // defaultFrameCodec.
+      return Optional.empty();
+    }
+  }
+
+  static FrameCodecWrapper defaultFrameCodec() {
+    return defaultFrameCodec;
+  }
+
+  static FrameCodecWrapper buildFrameCodec(Integer... protocolVersions) {
+    Set<Integer> versions = new TreeSet<>(Arrays.asList(protocolVersions));
+    return buildFrameCodec(versions);
+  }
+
+  static FrameCodecWrapper buildFrameCodec(Set<Integer> protocolVersions) {
+    if (protocolVersions.equals(defaultProtocolVersions)) {
+      return defaultFrameCodec;
+    }
+    List<FrameCodec.CodecGroup> codecGroups = new ArrayList<>();
+    for (int protocolVersion : protocolVersions) {
+      switch (protocolVersion) {
+        case 3:
+          codecGroups.add(new ProtocolV3ServerCodecs());
+          break;
+        case 4:
+          codecGroups.add(new ProtocolV4ServerCodecs());
+          break;
+        case 5:
+          codecGroups.add(new ProtocolV5ServerCodecs());
+          break;
+        default:
+          logger.warn("Unknown protocol versions '{}' provided, ignoring.", protocolVersion);
+      }
+    }
+    return new FrameCodecWrapper(
+        protocolVersions, codecGroups.toArray(new FrameCodec.CodecGroup[codecGroups.size()]));
+  }
+}

--- a/native-server/src/main/java/com/datastax/oss/simulacron/server/FrameCodecWrapper.java
+++ b/native-server/src/main/java/com/datastax/oss/simulacron/server/FrameCodecWrapper.java
@@ -15,9 +15,23 @@
  */
 package com.datastax.oss.simulacron.server;
 
-public enum RejectScope {
-  UNBIND, // unbind the channel so can't establish TCP connection
-  STOP, // unbind the channel and close all nodes, similar to as if a node had been stopped.
-  REJECT_STARTUP // keep channel bound so can establish TCP connection, but doesn't reply to
-  // startup.
+import com.datastax.oss.protocol.internal.Compressor;
+import com.datastax.oss.protocol.internal.FrameCodec;
+import io.netty.buffer.ByteBuf;
+import java.util.Set;
+
+class FrameCodecWrapper extends FrameCodec<ByteBuf> {
+
+  private static final ByteBufCodec codec = new ByteBufCodec();
+
+  private final Set<Integer> supportedProtocolVersions;
+
+  FrameCodecWrapper(Set<Integer> supportedProtocolVersions, CodecGroup... codecGroups) {
+    super(codec, Compressor.none(), codecGroups);
+    this.supportedProtocolVersions = supportedProtocolVersions;
+  }
+
+  Set<Integer> getSupportedProtocolVersions() {
+    return supportedProtocolVersions;
+  }
 }

--- a/native-server/src/main/java/com/datastax/oss/simulacron/server/Server.java
+++ b/native-server/src/main/java/com/datastax/oss/simulacron/server/Server.java
@@ -533,12 +533,7 @@ public final class Server implements AutoCloseable {
                 BoundNode node =
                     new BoundNode(
                         address,
-                        refNode.getName(),
-                        refNode.getId() != null
-                            ? refNode.getId()
-                            : 0, // assign id 0 if this is a standalone node.
-                        refNode.getCassandraVersion(),
-                        refNode.getDSEVersion(),
+                        refNode,
                         newPeerInfo,
                         cluster,
                         parent,
@@ -618,8 +613,8 @@ public final class Server implements AutoCloseable {
                         }
                         // If event loop was created for Server, shut it down.
                         if (!customEventLoop) {
-                          // Immediate shutdown should be appropriate since we unregister first so nothing should be
-                          // happening on event loop.
+                          // Immediate shutdown should be appropriate since we unregister first so
+                          // nothing should be happening on event loop.
                           Future<?> future =
                               eventLoopGroup.shutdownGracefully(0, 1, TimeUnit.SECONDS);
                           // adapt future to completable future by calling get on common pool.
@@ -837,8 +832,8 @@ public final class Server implements AutoCloseable {
         logger.debug("Got new connection {}", channel);
 
         pipeline
-            .addLast("decoder", new FrameDecoder(frameCodec))
-            .addLast("encoder", new FrameEncoder(frameCodec))
+            .addLast("decoder", new FrameDecoder(node.getFrameCodec()))
+            .addLast("encoder", new FrameEncoder(node.getFrameCodec()))
             .addLast("requestHandler", new RequestHandler(node));
       } finally {
         MDC.remove("node");

--- a/native-server/src/test/java/com/datastax/oss/simulacron/server/AddressResolverIntegrationTest.java
+++ b/native-server/src/test/java/com/datastax/oss/simulacron/server/AddressResolverIntegrationTest.java
@@ -35,8 +35,8 @@ public class AddressResolverIntegrationTest {
 
   @Test
   public void testAddressesReused() throws Exception {
-    // Validate that when a Cluster is unregistered, the ip addresses used can be reassigned to subsequently
-    // created clusters.
+    // Validate that when a Cluster is unregistered, the ip addresses used can be reassigned to
+    // subsequently created clusters.
     ClusterSpec cluster0 = ClusterSpec.builder().withNodes(3, 3, 3).build();
     BoundCluster boundCluster0 = server.register(cluster0);
 
@@ -60,8 +60,8 @@ public class AddressResolverIntegrationTest {
 
   @Test
   public void testAddressesReassignedInSameOrder() throws Exception {
-    // Validate that when a Cluster is unregistered, the ip addresses used can be reassigned to subsequently
-    // created clusters.
+    // Validate that when a Cluster is unregistered, the ip addresses used can be reassigned to
+    // subsequently created clusters.
     // Also affirms that the order of nodes and data centers within clusters is consistent.
     List<SocketAddress> lastAddresses = null;
 

--- a/native-server/src/test/java/com/datastax/oss/simulacron/server/BoundNodeTest.java
+++ b/native-server/src/test/java/com/datastax/oss/simulacron/server/BoundNodeTest.java
@@ -36,6 +36,7 @@ import com.datastax.oss.protocol.internal.response.result.SetKeyspace;
 import com.datastax.oss.protocol.internal.response.result.Void;
 import com.datastax.oss.simulacron.common.cluster.AbstractNode;
 import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+import com.datastax.oss.simulacron.common.cluster.NodeSpec;
 import com.datastax.oss.simulacron.common.cluster.QueryLog;
 import com.datastax.oss.simulacron.common.codec.ConsistencyLevel;
 import com.datastax.oss.simulacron.common.stubbing.Action;
@@ -64,10 +65,7 @@ public class BoundNodeTest {
   private final BoundNode node =
       new BoundNode(
           new LocalAddress(UUID.randomUUID().toString()),
-          "node0",
-          0L,
-          "1.2.19",
-          null,
+          NodeSpec.builder().withName("node0").withId(0L).withCassandraVersion("1.2.19").build(),
           Collections.emptyMap(),
           cluster,
           dc,
@@ -79,10 +77,7 @@ public class BoundNodeTest {
   private final BoundNode loggedNode =
       new BoundNode(
           new LocalAddress(UUID.randomUUID().toString()),
-          "node0",
-          0L,
-          "1.2.19",
-          null,
+          NodeSpec.builder().withName("node0").withId(0L).withCassandraVersion("1.2.19").build(),
           Collections.emptyMap(),
           cluster,
           dc,
@@ -196,7 +191,7 @@ public class BoundNodeTest {
   }
 
   @Test
-  public void shouldRespondWithStubActionsWhenMatched() throws Exception {
+  public void shouldRespondWithStubActionsWhenMatched() {
     String query = "select * from foo where bar = ?";
     RowsMetadata rowsMetadata = new RowsMetadata(Collections.emptyList(), null, new int[0], null);
     Prepared response = new Prepared(new byte[] {1, 7, 9}, null, rowsMetadata, rowsMetadata);
@@ -209,9 +204,7 @@ public class BoundNodeTest {
                 Message msg = frame.message;
                 if (msg instanceof Prepare) {
                   Prepare p = (Prepare) msg;
-                  if (p.cqlQuery.equals(query)) {
-                    return true;
-                  }
+                  return p.cqlQuery.equals(query);
                 }
                 return false;
               }
@@ -242,9 +235,7 @@ public class BoundNodeTest {
                 Message msg = frame.message;
                 if (msg instanceof Prepare) {
                   Prepare p = (Prepare) msg;
-                  if (p.cqlQuery.equals(query)) {
-                    return true;
-                  }
+                  return p.cqlQuery.equals(query);
                 }
                 return false;
               }

--- a/native-server/src/test/java/com/datastax/oss/simulacron/server/DisconnectActionTest.java
+++ b/native-server/src/test/java/com/datastax/oss/simulacron/server/DisconnectActionTest.java
@@ -63,8 +63,8 @@ public class DisconnectActionTest {
 
   @Test
   public void testCloseConnection() throws Exception {
-    // Validate that when a stub dictates to close a connection it does so and does not close the NodeSpec's channel so it
-    // can remain accepting traffic.
+    // Validate that when a stub dictates to close a connection it does so and does not close the
+    // NodeSpec's channel so it can remain accepting traffic.
     NodeSpec node = NodeSpec.builder().build();
     BoundNode boundNode = localServer.register(node);
 

--- a/native-server/src/test/java/com/datastax/oss/simulacron/server/MockClient.java
+++ b/native-server/src/test/java/com/datastax/oss/simulacron/server/MockClient.java
@@ -47,7 +47,8 @@ public class MockClient implements Closeable {
   Channel channel;
 
   MockClient(EventLoopGroup elg, FrameCodec<ByteBuf> frameCodec) {
-    // Set up so written Frames are encoded into bytes, received bytes are encoded into Frames put on queue.
+    // Set up so written Frames are encoded into bytes, received bytes are encoded into Frames put
+    // on queue.
     cb.group(elg)
         .channel(LocalChannel.class)
         .handler(
@@ -56,7 +57,7 @@ public class MockClient implements Closeable {
               protected void initChannel(LocalChannel ch) throws Exception {
                 ch.pipeline()
                     .addLast(new FrameEncoder(frameCodec))
-                    .addLast(new FrameDecoder(frameCodec))
+                    .addLast(new TestFrameDecoder(frameCodec))
                     .addLast(
                         new ChannelInboundHandlerAdapter() {
                           @Override
@@ -101,7 +102,7 @@ public class MockClient implements Closeable {
         this.channel.close().sync();
       }
     } catch (InterruptedException e) {
-      //no op
+      // no op
     }
   }
 }

--- a/native-server/src/test/java/com/datastax/oss/simulacron/server/ProtocolVersionSupportTest.java
+++ b/native-server/src/test/java/com/datastax/oss/simulacron/server/ProtocolVersionSupportTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+import com.datastax.oss.simulacron.common.cluster.DataCenterSpec;
+import com.datastax.oss.simulacron.common.cluster.NodeSpec;
+import io.netty.channel.local.LocalAddress;
+import io.netty.util.HashedWheelTimer;
+import io.netty.util.Timer;
+import java.util.Collections;
+import java.util.UUID;
+import org.assertj.core.util.Lists;
+import org.junit.Test;
+
+public class ProtocolVersionSupportTest {
+
+  private static final Timer timer = new HashedWheelTimer();
+
+  @Test
+  public void testShouldSetV3andV4ByDefault() {
+    testProtocolVersionForCassandraVersion(null, 3, 4);
+  }
+
+  @Test
+  public void testShouldSetV3ForCassandra21() {
+    testProtocolVersionForCassandraVersion("2.1.17", 3);
+  }
+
+  @Test
+  public void testShouldSetV3andV4ForCassandra22() {
+    testProtocolVersionForCassandraVersion("2.2.11", 3, 4);
+  }
+
+  @Test
+  public void testShouldSetV3andV4ForCassandra30() {
+    testProtocolVersionForCassandraVersion("3.0.17", 3, 4);
+  }
+
+  @Test
+  public void testShouldSetV3andV4andV5ForCassandra40() {
+    testProtocolVersionForCassandraVersion("4.0.0", 3, 4, 5);
+  }
+
+  @Test
+  public void shouldInheritClusterOverride() {
+    BoundCluster cluster =
+        new BoundCluster(
+            ClusterSpec.builder().withPeerInfo("protocol_versions", Lists.newArrayList(5)).build(),
+            0L,
+            null);
+    BoundDataCenter dc = new BoundDataCenter(cluster);
+    BoundNode node =
+        new BoundNode(
+            new LocalAddress(UUID.randomUUID().toString()),
+            NodeSpec.builder().withName("node0").withId(0L).build(),
+            Collections.emptyMap(),
+            cluster,
+            dc,
+            null,
+            timer,
+            null, // channel reference only needed for closing, not useful in context of this test.
+            false);
+
+    assertThat(node.getFrameCodec().getSupportedProtocolVersions()).containsOnly(5);
+    assertThat(dc.getFrameCodec().getSupportedProtocolVersions()).containsOnly(5);
+    assertThat(cluster.getFrameCodec().getSupportedProtocolVersions()).containsOnly(5);
+  }
+
+  @Test
+  public void shouldInheritClusterOverrideFromCassandraVersion() {
+    BoundCluster cluster =
+        new BoundCluster(ClusterSpec.builder().withCassandraVersion("2.1.17").build(), 0L, null);
+    BoundDataCenter dc = new BoundDataCenter(cluster);
+    BoundNode node =
+        new BoundNode(
+            new LocalAddress(UUID.randomUUID().toString()),
+            NodeSpec.builder().withName("node0").withId(0L).build(),
+            Collections.emptyMap(),
+            cluster,
+            dc,
+            null,
+            timer,
+            null, // channel reference only needed for closing, not useful in context of this test.
+            false);
+
+    assertThat(node.getFrameCodec().getSupportedProtocolVersions()).containsOnly(3);
+    assertThat(dc.getFrameCodec().getSupportedProtocolVersions()).containsOnly(3);
+    assertThat(cluster.getFrameCodec().getSupportedProtocolVersions()).containsOnly(3);
+  }
+
+  @Test
+  public void shouldInheritDCOverride() {
+    ClusterSpec clusterSpec =
+        ClusterSpec.builder().withPeerInfo("protocol_versions", Lists.newArrayList(5)).build();
+    BoundCluster cluster = new BoundCluster(clusterSpec, 0L, null);
+    DataCenterSpec dcSpec =
+        clusterSpec
+            .addDataCenter()
+            .withPeerInfo("protocol_versions", Lists.newArrayList(4))
+            .build();
+    BoundDataCenter dc = new BoundDataCenter(dcSpec, cluster);
+    BoundNode node =
+        new BoundNode(
+            new LocalAddress(UUID.randomUUID().toString()),
+            NodeSpec.builder().withName("node0").withId(0L).build(),
+            Collections.emptyMap(),
+            cluster,
+            dc,
+            null,
+            timer,
+            null, // channel reference only needed for closing, not useful in context of this test.
+            false);
+
+    assertThat(node.getFrameCodec().getSupportedProtocolVersions()).containsOnly(4);
+    assertThat(dc.getFrameCodec().getSupportedProtocolVersions()).containsOnly(4);
+    assertThat(cluster.getFrameCodec().getSupportedProtocolVersions()).containsOnly(5);
+  }
+
+  @Test
+  public void testShouldUseProtocolVersionOverride() {
+    BoundCluster cluster = new BoundCluster(ClusterSpec.builder().build(), 0L, null);
+    BoundDataCenter dc = new BoundDataCenter(cluster);
+    BoundNode node =
+        new BoundNode(
+            new LocalAddress(UUID.randomUUID().toString()),
+            NodeSpec.builder()
+                .withName("node0")
+                .withId(0L)
+                .withCassandraVersion("2.1.17")
+                .withPeerInfo("protocol_versions", Lists.newArrayList(4))
+                .build(),
+            Collections.emptyMap(),
+            cluster,
+            dc,
+            null,
+            timer,
+            null, // channel reference only needed for closing, not useful in context of this test.
+            false);
+
+    assertThat(node.getFrameCodec().getSupportedProtocolVersions()).containsOnly(4);
+  }
+
+  public void testProtocolVersionForCassandraVersion(
+      String cassandraVersion, Integer... expectedProtocolVersions) {
+    BoundCluster cluster = new BoundCluster(ClusterSpec.builder().build(), 0L, null);
+    BoundDataCenter dc = new BoundDataCenter(cluster);
+    BoundNode node =
+        new BoundNode(
+            new LocalAddress(UUID.randomUUID().toString()),
+            NodeSpec.builder()
+                .withName("node0")
+                .withId(0L)
+                .withCassandraVersion(cassandraVersion)
+                .build(),
+            Collections.emptyMap(),
+            cluster,
+            dc,
+            null,
+            timer,
+            null, // channel reference only needed for closing, not useful in context of this test.
+            false);
+
+    assertThat(node.getFrameCodec().getSupportedProtocolVersions())
+        .containsOnly(expectedProtocolVersions);
+  }
+}

--- a/native-server/src/test/java/com/datastax/oss/simulacron/server/TestFrameDecoder.java
+++ b/native-server/src/test/java/com/datastax/oss/simulacron/server/TestFrameDecoder.java
@@ -16,27 +16,23 @@
 package com.datastax.oss.simulacron.server;
 
 import com.datastax.oss.protocol.internal.Frame;
-import com.datastax.oss.protocol.internal.Message;
-import com.datastax.oss.protocol.internal.ProtocolConstants;
-import com.datastax.oss.protocol.internal.response.Error;
-import com.datastax.oss.simulacron.common.utils.FrameUtils;
+import com.datastax.oss.protocol.internal.FrameCodec;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
-import java.util.Collections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class FrameDecoder extends LengthFieldBasedFrameDecoder {
+public class TestFrameDecoder extends LengthFieldBasedFrameDecoder {
   private static final Logger logger = LoggerFactory.getLogger(FrameDecoder.class);
-  private final FrameCodecWrapper frameCodec;
+  private final FrameCodec<ByteBuf> frameCodec;
 
   private static final int MAX_FRAME_LENGTH = 256 * 1024 * 1024; // 256 MB
   private static final int HEADER_LENGTH =
       5; // size of the header = version (1) + flags (1) + stream id (2) + opcode (1)
   private static final int LENGTH_FIELD_LENGTH = 4; // length of the length field.
 
-  FrameDecoder(FrameCodecWrapper frameCodec) {
+  TestFrameDecoder(FrameCodec<ByteBuf> frameCodec) {
     super(MAX_FRAME_LENGTH, HEADER_LENGTH, LENGTH_FIELD_LENGTH, 0, 0, true);
 
     this.frameCodec = frameCodec;
@@ -47,37 +43,6 @@ public class FrameDecoder extends LengthFieldBasedFrameDecoder {
     if (buffer.readableBytes() < HEADER_LENGTH) return null;
     ByteBuf contents = (ByteBuf) super.decode(ctx, buffer);
     if (contents == null) return null;
-
-    // handle case where protocol version is greater than what is supported.
-    int protocolVersion = contents.getByte(contents.readerIndex()) & 0x7F;
-    if (!frameCodec.getSupportedProtocolVersions().contains(protocolVersion)) {
-      logger.warn(
-          "Received message with unsupported protocol version {}, sending back protocol error.",
-          protocolVersion);
-
-      int streamId = contents.getShort(contents.readerIndex() + 2);
-      Message message =
-          new Error(
-              ProtocolConstants.ErrorCode.PROTOCOL_ERROR,
-              "Invalid or unsupported protocol version");
-
-      // Respond with max protocol version supported.
-      Frame frame =
-          new Frame(
-              Collections.max(frameCodec.getSupportedProtocolVersions()),
-              false,
-              streamId,
-              false,
-              null,
-              FrameUtils.emptyCustomPayload,
-              Collections.emptyList(),
-              message);
-      ctx.writeAndFlush(frameCodec.encode(frame));
-      int length = contents.getInt(contents.readerIndex() + 5);
-      // discard the frame.
-      contents.skipBytes(9 + length);
-      return null;
-    }
     return frameCodec.decode(contents);
   }
 

--- a/standalone/src/main/java/com/datastax/oss/simulacron/standalone/App.java
+++ b/standalone/src/main/java/com/datastax/oss/simulacron/standalone/App.java
@@ -82,7 +82,8 @@ public class App {
             .withActivityLoggingEnabled(!cli.disableActivityLogging)
             .build();
 
-    // TODO: There should probably be a module in http-server for setting up the http server instead of doing it here.
+    // TODO: There should probably be a module in http-server for setting up the http server instead
+    // of doing it here.
     ClusterManager provisioner = new ClusterManager(nativeServer);
     provisioner.registerWithRouter(httpServer.getRouter());
 


### PR DESCRIPTION
Fixes #10 and #22

Provides the following changes:

* Protocol V5 support
* Detection of supported Protocol Versions based on the C* version.
* To override protocol versions, provide `protocol_versions` json list of numbers in `peer_info`, i.e.:

    ```json
     {
        "peer_info": {
            "protocol_versions": [3, 4, 5]
         }
     }
    ```
* If unsupported protocol version provided in frame by user, simulacron will respond with error with it's highest supported protocol version.
* Also updates `fmt-maven-plugin` so there is some formatting changes included here too.