### PR TITLE
[#6] Include frame in /log JSON

### DIFF
--- a/common/src/main/java/com/datastax/oss/simulacron/common/cluster/ObjectMapperHolder.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/cluster/ObjectMapperHolder.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.simulacron.common.cluster;
 
+import com.datastax.oss.simulacron.protocol.json.NativeProtocolModule;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -41,6 +42,7 @@ public class ObjectMapperHolder {
     mod.addKeySerializer(InetAddress.class, new InetAddressSerializer());
     mod.addKeyDeserializer(InetAddress.class, new InetAddressDeserializer());
     om.registerModule(mod);
+    om.registerModule(NativeProtocolModule.module());
     OBJECT_MAPPER = om;
   }
 

--- a/common/src/main/java/com/datastax/oss/simulacron/common/cluster/QueryLog.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/cluster/QueryLog.java
@@ -24,7 +24,6 @@ import com.datastax.oss.simulacron.common.codec.ConsistencyLevel;
 import com.datastax.oss.simulacron.common.stubbing.Prime;
 import com.datastax.oss.simulacron.common.stubbing.StubMapping;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.net.SocketAddress;
 import java.util.Optional;
@@ -55,7 +54,8 @@ public class QueryLog {
   @JsonProperty("primed")
   private boolean primed;
 
-  @JsonIgnore private Frame frame;
+  @JsonProperty(value = "frame", access = JsonProperty.Access.READ_ONLY)
+  private Frame frame;
 
   @JsonCreator
   public QueryLog(
@@ -123,18 +123,22 @@ public class QueryLog {
     }
   }
 
+  /** @deprecated Use frame instead. */
   public String getType() {
     return type;
   }
 
+  /** @deprecated Use frame instead. */
   public String getQuery() {
     return query;
   }
 
+  /** @deprecated Use frame instead. */
   public ConsistencyLevel getConsistency() {
     return consistency;
   }
 
+  /** @deprecated Use frame instead. */
   public ConsistencyLevel getSerialConsistency() {
     return serialConsistency;
   }
@@ -147,6 +151,8 @@ public class QueryLog {
     return receivedTimestamp;
   }
 
+  /** @deprecated Use frame instead. */
+  @Deprecated
   public long getClientTimestamp() {
     return clientTimestamp;
   }
@@ -156,7 +162,6 @@ public class QueryLog {
   }
 
   /** @return The frame associated with this log if present. */
-  @JsonIgnore
   public Frame getFrame() {
     return this.frame;
   }

--- a/http-server/src/main/resources/webroot/swagger/swagger.yaml
+++ b/http-server/src/main/resources/webroot/swagger/swagger.yaml
@@ -2625,18 +2625,6 @@ definitions:
   QueryLog:
     type: object
     properties:
-      type:
-        type: string
-        example: "QUERY"
-      query:
-        type: string
-        example: "select * from tbl"
-      consistency_level:
-        type: string
-        example: "LOCAL_QUORUM"
-      serial_consistency_level:
-        type: string
-        example: "SERIAL"
       connection:
         type: string
         example: "/127.0.0.1:34662"
@@ -2644,14 +2632,34 @@ definitions:
         type: long
         description: Timestamp when query was received (Epoch time in milliseconds)
         example: 1496955368551
-      client_timestamp:
-        type: long
-        description: Timestamp specified in query (Epoch time in milliseconds)
-        example: 1496955368551
       primed:
         type: boolean
         description: Whether or not the query had a matching prime
         example: true
+      frame:
+        type: object
+        example:
+          protocol_version: 4
+          beta: false
+          stream_id: 128
+          tracing_id: null
+          custom_payload: {}
+          warnings: []
+          message:
+            type: QUERY
+            opcode: 7
+            is_response: false
+            query: select * from tbl
+            options:
+              consistency: LOCAL_ONE
+              positional_values: []
+              named_values: {}
+              skip_metadata: false
+              page_size: 5000
+              paging_state: null
+              serial_consistency: SERIAL
+              default_timestamp: 100
+              keyspace: null
   NodeQueryLogReport:
     type: object
     required:

--- a/native-protocol-json/pom.xml
+++ b/native-protocol-json/pom.xml
@@ -23,10 +23,10 @@
     <version>0.7.1-SNAPSHOT</version>
   </parent>
 
-  <artifactId>simulacron-common</artifactId>
+  <artifactId>simulacron-native-protocol-json</artifactId>
   <packaging>jar</packaging>
 
-  <name>simulacron common</name>
+  <name>simulacron native protocol json serializers</name>
 
   <dependencies>
     <dependency>
@@ -38,11 +38,6 @@
       <groupId>com.datastax.oss</groupId>
       <artifactId>native-protocol</artifactId>
       <version>${native-protocol.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.datastax.oss.simulacron</groupId>
-      <artifactId>simulacron-native-protocol-json</artifactId>
-      <version>${project.parent.version}</version>
     </dependency>
   </dependencies>
 

--- a/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/AuthResponseSerializer.java
+++ b/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/AuthResponseSerializer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.protocol.json;
+
+import com.datastax.oss.protocol.internal.request.AuthResponse;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+
+public class AuthResponseSerializer extends MessageSerializer<AuthResponse> {
+  @Override
+  public void serializeMessage(
+      AuthResponse authResponse, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException {
+    jsonGenerator.writeObjectField("token", authResponse.token);
+  }
+}

--- a/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/AuthenticateSerializer.java
+++ b/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/AuthenticateSerializer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.protocol.json;
+
+import com.datastax.oss.protocol.internal.response.Authenticate;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+
+public class AuthenticateSerializer extends MessageSerializer<Authenticate> {
+
+  @Override
+  public void serializeMessage(
+      Authenticate authenticate, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException {
+    jsonGenerator.writeObjectField("authenticator", authenticate.authenticator);
+  }
+}

--- a/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/BatchSerializer.java
+++ b/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/BatchSerializer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.protocol.json;
+
+import static com.datastax.oss.simulacron.protocol.json.SerializerUtils.toConsistencyString;
+
+import com.datastax.oss.protocol.internal.request.Batch;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+
+public class BatchSerializer extends MessageSerializer<Batch> {
+  @Override
+  public void serializeMessage(
+      Batch batch, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException {
+
+    final String batchType;
+    switch (batch.type) {
+      case 0x0:
+        batchType = "LOGGED";
+        break;
+      case 0x1:
+        batchType = "UNLOGGED";
+        break;
+      case 0x2:
+        batchType = "COUNTER";
+        break;
+      default:
+        batchType = "" + batch.type;
+    }
+
+    jsonGenerator.writeObjectField("type", batchType);
+    jsonGenerator.writeObjectField("queries_or_ids", batch.queriesOrIds);
+    jsonGenerator.writeObjectField("values", batch.values);
+    jsonGenerator.writeObjectField("consistency", toConsistencyString(batch.consistency));
+    jsonGenerator.writeObjectField(
+        "serial_consistency", toConsistencyString(batch.serialConsistency));
+    jsonGenerator.writeObjectField("default_timestamp", batch.defaultTimestamp);
+    jsonGenerator.writeObjectField("keyspace", batch.keyspace);
+  }
+}

--- a/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/ExecuteSerializer.java
+++ b/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/ExecuteSerializer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.protocol.json;
+
+import com.datastax.oss.protocol.internal.request.Execute;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class ExecuteSerializer extends MessageSerializer<Execute> {
+  @Override
+  public void serializeMessage(
+      Execute execute, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException {
+    jsonGenerator.writeObjectField("id", ByteBuffer.wrap(execute.queryId));
+    jsonGenerator.writeObjectField(
+        "result_metadata_id",
+        execute.resultMetadataId != null ? ByteBuffer.wrap(execute.resultMetadataId) : null);
+    jsonGenerator.writeObjectField("options", execute.options);
+  }
+}

--- a/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/FallthroughMessageSerializer.java
+++ b/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/FallthroughMessageSerializer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.protocol.json;
+
+import com.datastax.oss.protocol.internal.Message;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+
+public class FallthroughMessageSerializer extends MessageSerializer<Message> {
+  public void serializeMessage(
+      Message message, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException {}
+}

--- a/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/FrameSerializer.java
+++ b/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/FrameSerializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.protocol.json;
+
+import com.datastax.oss.protocol.internal.Frame;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+
+public class FrameSerializer extends JsonSerializer<Frame> {
+  @Override
+  public void serialize(
+      Frame frame, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException {
+    jsonGenerator.writeStartObject(frame);
+    jsonGenerator.writeObjectField("protocol_version", frame.protocolVersion);
+    jsonGenerator.writeObjectField("beta", frame.beta);
+    jsonGenerator.writeObjectField("stream_id", frame.streamId);
+    jsonGenerator.writeObjectField("tracing_id", frame.tracing ? frame.tracingId.toString() : null);
+    jsonGenerator.writeObjectField("custom_payload", frame.customPayload);
+    jsonGenerator.writeObjectField("warnings", frame.warnings);
+    jsonGenerator.writeObjectField("message", frame.message);
+    jsonGenerator.writeEndObject();
+  }
+}

--- a/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/MessageSerializer.java
+++ b/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/MessageSerializer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.protocol.json;
+
+import com.datastax.oss.protocol.internal.Message;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+
+public abstract class MessageSerializer<T extends Message> extends JsonSerializer<T> {
+  @Override
+  public void serialize(
+      T message, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException {
+    jsonGenerator.writeStartObject(message);
+    serializeInner(message, jsonGenerator, serializerProvider);
+    serializeMessage(message, jsonGenerator, serializerProvider);
+    jsonGenerator.writeEndObject();
+  }
+
+  public abstract void serializeMessage(
+      T message, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException;
+
+  void serializeInner(T message, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException {
+    jsonGenerator.writeObjectField("type", message.getClass().getSimpleName().toUpperCase());
+    jsonGenerator.writeObjectField("opcode", message.opcode);
+    jsonGenerator.writeObjectField("is_response", message.isResponse);
+  }
+}

--- a/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/NativeProtocolModule.java
+++ b/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/NativeProtocolModule.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.protocol.json;
+
+import com.datastax.oss.protocol.internal.Frame;
+import com.datastax.oss.protocol.internal.Message;
+import com.datastax.oss.protocol.internal.request.AuthResponse;
+import com.datastax.oss.protocol.internal.request.Batch;
+import com.datastax.oss.protocol.internal.request.Execute;
+import com.datastax.oss.protocol.internal.request.Prepare;
+import com.datastax.oss.protocol.internal.request.Query;
+import com.datastax.oss.protocol.internal.request.Register;
+import com.datastax.oss.protocol.internal.request.Startup;
+import com.datastax.oss.protocol.internal.request.query.QueryOptions;
+import com.datastax.oss.protocol.internal.response.Authenticate;
+import com.datastax.oss.protocol.internal.response.Supported;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class NativeProtocolModule {
+
+  private static final SimpleModule module = new SimpleModule("NativeProtocol");
+
+  static {
+    // Frame serializer
+    module.addSerializer(Frame.class, new FrameSerializer());
+
+    // Message serializers
+    // Currently serializers are only implemented for requests as thats all we are interested in
+    // serializing at the moment in Simulacron.
+    module.addSerializer(Startup.class, new StartupSerializer());
+    module.addSerializer(Authenticate.class, new AuthenticateSerializer());
+    module.addSerializer(Supported.class, new SupportedSerializer());
+    module.addSerializer(Query.class, new QuerySerializer());
+    module.addSerializer(Prepare.class, new PrepareSerializer());
+    module.addSerializer(Execute.class, new ExecuteSerializer());
+    module.addSerializer(Register.class, new RegisterSerializer());
+    module.addSerializer(Batch.class, new BatchSerializer());
+    module.addSerializer(AuthResponse.class, new AuthResponseSerializer());
+    // catch all for messages that are not implemented / needed (i.e. OPTIONS, READY).
+    module.addSerializer(Message.class, new FallthroughMessageSerializer());
+
+    // Query Options
+    module.addSerializer(QueryOptions.class, new QueryOptionsSerializer());
+  }
+
+  public static SimpleModule module() {
+    return module;
+  }
+}

--- a/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/PrepareSerializer.java
+++ b/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/PrepareSerializer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.protocol.json;
+
+import com.datastax.oss.protocol.internal.request.Prepare;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+
+public class PrepareSerializer extends MessageSerializer<Prepare> {
+  @Override
+  public void serializeMessage(
+      Prepare prepare, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException {
+    jsonGenerator.writeObjectField("query", prepare.cqlQuery);
+    jsonGenerator.writeObjectField("keyspace", prepare.keyspace);
+  }
+}

--- a/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/QueryOptionsSerializer.java
+++ b/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/QueryOptionsSerializer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.protocol.json;
+
+import static com.datastax.oss.simulacron.protocol.json.SerializerUtils.toConsistencyString;
+
+import com.datastax.oss.protocol.internal.request.query.QueryOptions;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+
+public class QueryOptionsSerializer extends JsonSerializer<QueryOptions> {
+  @Override
+  public void serialize(
+      QueryOptions queryOptions, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException {
+    jsonGenerator.writeStartObject(queryOptions);
+    jsonGenerator.writeObjectField("consistency", toConsistencyString(queryOptions.consistency));
+    jsonGenerator.writeObjectField("positional_values", queryOptions.positionalValues);
+    jsonGenerator.writeObjectField("named_values", queryOptions.namedValues);
+    jsonGenerator.writeObjectField("skip_metadata", queryOptions.skipMetadata);
+    jsonGenerator.writeObjectField("page_size", queryOptions.pageSize);
+    jsonGenerator.writeObjectField("paging_state", queryOptions.pagingState);
+    jsonGenerator.writeObjectField(
+        "serial_consistency", toConsistencyString(queryOptions.serialConsistency));
+    jsonGenerator.writeObjectField("default_timestamp", queryOptions.defaultTimestamp);
+    jsonGenerator.writeObjectField("keyspace", queryOptions.keyspace);
+    jsonGenerator.writeEndObject();
+  }
+}

--- a/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/QuerySerializer.java
+++ b/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/QuerySerializer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.protocol.json;
+
+import com.datastax.oss.protocol.internal.request.Query;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+
+public class QuerySerializer extends MessageSerializer<Query> {
+  @Override
+  public void serializeMessage(
+      Query query, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException {
+    jsonGenerator.writeObjectField("query", query.query);
+    jsonGenerator.writeObjectField("options", query.options);
+  }
+}

--- a/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/RegisterSerializer.java
+++ b/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/RegisterSerializer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.protocol.json;
+
+import com.datastax.oss.protocol.internal.request.Register;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+
+public class RegisterSerializer extends MessageSerializer<Register> {
+
+  @Override
+  public void serializeMessage(
+      Register register, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException {
+    jsonGenerator.writeObjectField("event_types", register.eventTypes);
+  }
+}

--- a/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/SerializerUtils.java
+++ b/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/SerializerUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.protocol.json;
+
+public class SerializerUtils {
+
+  public static String toConsistencyString(int consistency) {
+    switch (consistency) {
+      case 0:
+        return "ANY";
+      case 1:
+        return "ONE";
+      case 2:
+        return "TWO";
+      case 3:
+        return "THREE";
+      case 4:
+        return "QUORUM";
+      case 5:
+        return "ALL";
+      case 6:
+        return "LOCAL_QUORUM";
+      case 7:
+        return "EACH_QUORUM";
+      case 8:
+        return "SERIAL";
+      case 9:
+        return "LOCAL_SERIAL";
+      case 10:
+        return "LOCAL_ONE";
+      default:
+        return "" + consistency;
+    }
+  }
+}

--- a/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/StartupSerializer.java
+++ b/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/StartupSerializer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.protocol.json;
+
+import com.datastax.oss.protocol.internal.request.Startup;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+
+public class StartupSerializer extends MessageSerializer<Startup> {
+
+  @Override
+  public void serializeMessage(
+      Startup startup, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException {
+    jsonGenerator.writeObjectField("options", startup.options);
+  }
+}

--- a/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/SupportedSerializer.java
+++ b/native-protocol-json/src/main/java/com/datastax/oss/simulacron/protocol/json/SupportedSerializer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.protocol.json;
+
+import com.datastax.oss.protocol.internal.response.Supported;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+
+public class SupportedSerializer extends MessageSerializer<Supported> {
+  @Override
+  public void serializeMessage(
+      Supported supported, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException {
+    jsonGenerator.writeObjectField("options", supported.options);
+  }
+}

--- a/native-protocol-json/src/test/java/com/datastax/oss/simulacron/protocol/json/FrameSerializerTest.java
+++ b/native-protocol-json/src/test/java/com/datastax/oss/simulacron/protocol/json/FrameSerializerTest.java
@@ -1,0 +1,514 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.protocol.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.protocol.internal.Frame;
+import com.datastax.oss.protocol.internal.request.AuthResponse;
+import com.datastax.oss.protocol.internal.request.Batch;
+import com.datastax.oss.protocol.internal.request.Execute;
+import com.datastax.oss.protocol.internal.request.Prepare;
+import com.datastax.oss.protocol.internal.request.Query;
+import com.datastax.oss.protocol.internal.request.Register;
+import com.datastax.oss.protocol.internal.request.Startup;
+import com.datastax.oss.protocol.internal.request.query.QueryOptions;
+import com.datastax.oss.protocol.internal.response.Authenticate;
+import com.datastax.oss.protocol.internal.response.Supported;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.assertj.core.util.Lists;
+import org.assertj.core.util.Maps;
+import org.junit.Test;
+
+public class FrameSerializerTest {
+
+  private static final ObjectMapper mapper = new ObjectMapper();
+  private static final ObjectWriter writer;
+  private static final long time = 1513196542339L;
+
+  static {
+    mapper.registerModule(NativeProtocolModule.module());
+    writer = mapper.writerWithDefaultPrettyPrinter();
+  }
+
+  @Test
+  public void testSimpleFrameWarningsAndCustomPayload() throws Exception {
+    UUID uuid = UUID.fromString("ce565629-e8e4-4f93-bdd4-9414b7d9d342");
+    // 0x0708 == Bwg= base64 encoded
+    Map<String, ByteBuffer> customPayload =
+        Maps.newHashMap("custom", ByteBuffer.wrap(new byte[] {0x7, 0x8}));
+    Frame frame =
+        new Frame(
+            5,
+            true,
+            10,
+            true,
+            uuid,
+            customPayload,
+            Lists.newArrayList("Something went wrong", "Fix me!"),
+            com.datastax.oss.protocol.internal.request.Options.INSTANCE);
+
+    String json = writer.writeValueAsString(frame);
+    assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"protocol_version\" : 5,\n"
+                + "  \"beta\" : true,\n"
+                + "  \"stream_id\" : 10,\n"
+                + "  \"tracing_id\" : \"ce565629-e8e4-4f93-bdd4-9414b7d9d342\",\n"
+                + "  \"custom_payload\" : {\n"
+                + "    \"custom\" : \"Bwg=\"\n"
+                + "  },\n"
+                + "  \"warnings\" : [ \"Something went wrong\", \"Fix me!\" ],\n"
+                + "  \"message\" : {\n"
+                + "    \"type\" : \"OPTIONS\",\n"
+                + "    \"opcode\" : 5,\n"
+                + "    \"is_response\" : false\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void testStartupFrame() throws Exception {
+    Frame frame =
+        new Frame(
+            4,
+            false,
+            10,
+            false,
+            null,
+            Collections.unmodifiableMap(new HashMap<>()),
+            Collections.emptyList(),
+            new Startup("LZ4"));
+
+    String json = writer.writeValueAsString(frame);
+    assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"protocol_version\" : 4,\n"
+                + "  \"beta\" : false,\n"
+                + "  \"stream_id\" : 10,\n"
+                + "  \"tracing_id\" : null,\n"
+                + "  \"custom_payload\" : { },\n"
+                + "  \"warnings\" : [ ],\n"
+                + "  \"message\" : {\n"
+                + "    \"type\" : \"STARTUP\",\n"
+                + "    \"opcode\" : 1,\n"
+                + "    \"is_response\" : false,\n"
+                + "    \"options\" : {\n"
+                + "      \"COMPRESSION\" : \"LZ4\",\n"
+                + "      \"CQL_VERSION\" : \"3.0.0\"\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void testAuthenticateFrame() throws Exception {
+    Frame frame =
+        new Frame(
+            4,
+            false,
+            10,
+            false,
+            null,
+            Collections.unmodifiableMap(new HashMap<>()),
+            Collections.emptyList(),
+            new Authenticate("AllowAllAuthenticator"));
+
+    String json = writer.writeValueAsString(frame);
+    assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"protocol_version\" : 4,\n"
+                + "  \"beta\" : false,\n"
+                + "  \"stream_id\" : 10,\n"
+                + "  \"tracing_id\" : null,\n"
+                + "  \"custom_payload\" : { },\n"
+                + "  \"warnings\" : [ ],\n"
+                + "  \"message\" : {\n"
+                + "    \"type\" : \"AUTHENTICATE\",\n"
+                + "    \"opcode\" : 3,\n"
+                + "    \"is_response\" : true,\n"
+                + "    \"authenticator\" : \"AllowAllAuthenticator\"\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void testSupportedFrame() throws Exception {
+    Map<String, List<String>> options = new LinkedHashMap<>();
+    options.put("a", Lists.newArrayList("1", "2", "3"));
+    options.put("b", Lists.newArrayList("hello"));
+    Frame frame =
+        new Frame(
+            4,
+            false,
+            10,
+            false,
+            null,
+            Collections.unmodifiableMap(new HashMap<>()),
+            Collections.emptyList(),
+            new Supported(options));
+
+    String json = writer.writeValueAsString(frame);
+    assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"protocol_version\" : 4,\n"
+                + "  \"beta\" : false,\n"
+                + "  \"stream_id\" : 10,\n"
+                + "  \"tracing_id\" : null,\n"
+                + "  \"custom_payload\" : { },\n"
+                + "  \"warnings\" : [ ],\n"
+                + "  \"message\" : {\n"
+                + "    \"type\" : \"SUPPORTED\",\n"
+                + "    \"opcode\" : 6,\n"
+                + "    \"is_response\" : true,\n"
+                + "    \"options\" : {\n"
+                + "      \"a\" : [ \"1\", \"2\", \"3\" ],\n"
+                + "      \"b\" : [ \"hello\" ]\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void testQueryPositionalValuesFrame() throws Exception {
+    ByteBuffer value0 = ByteBuffer.wrap(new byte[] {0x01, 0x02, 0x3}); // AQID base64 encoded
+    ByteBuffer value1 = ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0xc}); // CgsM base64 encoded
+    List<ByteBuffer> posValues = Lists.newArrayList(value0, value1);
+    Frame frame =
+        new Frame(
+            4,
+            false,
+            10,
+            false,
+            null,
+            Collections.unmodifiableMap(new HashMap<>()),
+            Collections.emptyList(),
+            new Query(
+                "select * from base",
+                new QueryOptions(
+                    2, posValues, Collections.emptyMap(), false, 1000, null, 8, time, "myks")));
+
+    String json = writer.writeValueAsString(frame);
+    assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"protocol_version\" : 4,\n"
+                + "  \"beta\" : false,\n"
+                + "  \"stream_id\" : 10,\n"
+                + "  \"tracing_id\" : null,\n"
+                + "  \"custom_payload\" : { },\n"
+                + "  \"warnings\" : [ ],\n"
+                + "  \"message\" : {\n"
+                + "    \"type\" : \"QUERY\",\n"
+                + "    \"opcode\" : 7,\n"
+                + "    \"is_response\" : false,\n"
+                + "    \"query\" : \"select * from base\",\n"
+                + "    \"options\" : {\n"
+                + "      \"consistency\" : \"TWO\",\n"
+                + "      \"positional_values\" : [ \"AQID\", \"CgsM\" ],\n"
+                + "      \"named_values\" : { },\n"
+                + "      \"skip_metadata\" : false,\n"
+                + "      \"page_size\" : 1000,\n"
+                + "      \"paging_state\" : null,\n"
+                + "      \"serial_consistency\" : \"SERIAL\",\n"
+                + "      \"default_timestamp\" : 1513196542339,\n"
+                + "      \"keyspace\" : \"myks\"\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void testQueryNamedValuesFrame() throws Exception {
+    ByteBuffer value0 = ByteBuffer.wrap(new byte[] {0x01, 0x02, 0x3}); // AQID base64 encoded
+    ByteBuffer value1 = ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0xc}); // CgsM base64 encoded
+    Map<String, ByteBuffer> namedValues = new LinkedHashMap<>();
+    namedValues.put("a", value0);
+    namedValues.put("b", value1);
+    ByteBuffer pagingState =
+        ByteBuffer.wrap(new byte[] {0xF, 0xD, 0x72, 0x7D, 0x52}); // Dw1yfVI= base64 encoded
+    Frame frame =
+        new Frame(
+            4,
+            false,
+            10,
+            false,
+            null,
+            Collections.unmodifiableMap(new HashMap<>()),
+            Collections.emptyList(),
+            new Query(
+                "select * from base",
+                new QueryOptions(
+                    2,
+                    Collections.emptyList(),
+                    namedValues,
+                    true,
+                    1000,
+                    pagingState,
+                    8,
+                    time,
+                    "myks")));
+
+    String json = writer.writeValueAsString(frame);
+    assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"protocol_version\" : 4,\n"
+                + "  \"beta\" : false,\n"
+                + "  \"stream_id\" : 10,\n"
+                + "  \"tracing_id\" : null,\n"
+                + "  \"custom_payload\" : { },\n"
+                + "  \"warnings\" : [ ],\n"
+                + "  \"message\" : {\n"
+                + "    \"type\" : \"QUERY\",\n"
+                + "    \"opcode\" : 7,\n"
+                + "    \"is_response\" : false,\n"
+                + "    \"query\" : \"select * from base\",\n"
+                + "    \"options\" : {\n"
+                + "      \"consistency\" : \"TWO\",\n"
+                + "      \"positional_values\" : [ ],\n"
+                + "      \"named_values\" : {\n"
+                + "        \"a\" : \"AQID\",\n"
+                + "        \"b\" : \"CgsM\"\n"
+                + "      },\n"
+                + "      \"skip_metadata\" : true,\n"
+                + "      \"page_size\" : 1000,\n"
+                + "      \"paging_state\" : \"Dw1yfVI=\",\n"
+                + "      \"serial_consistency\" : \"SERIAL\",\n"
+                + "      \"default_timestamp\" : 1513196542339,\n"
+                + "      \"keyspace\" : \"myks\"\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void testPrepareFrame() throws Exception {
+    Frame frame =
+        new Frame(
+            4,
+            false,
+            10,
+            false,
+            null,
+            Collections.unmodifiableMap(new HashMap<>()),
+            Collections.emptyList(),
+            new Prepare("select * from base where belong=?", "your"));
+
+    String json = writer.writeValueAsString(frame);
+    assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"protocol_version\" : 4,\n"
+                + "  \"beta\" : false,\n"
+                + "  \"stream_id\" : 10,\n"
+                + "  \"tracing_id\" : null,\n"
+                + "  \"custom_payload\" : { },\n"
+                + "  \"warnings\" : [ ],\n"
+                + "  \"message\" : {\n"
+                + "    \"type\" : \"PREPARE\",\n"
+                + "    \"opcode\" : 9,\n"
+                + "    \"is_response\" : false,\n"
+                + "    \"query\" : \"select * from base where belong=?\",\n"
+                + "    \"keyspace\" : \"your\"\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void testExecuteFrame() throws Exception {
+    byte id[] = new byte[] {0x01, 0x02, 0x3, 0x04}; // AQIDBA== base64 encoded
+    byte metadataId[] = new byte[] {0x4, 0x02, 0x3, 0x4}; // BAIDBA== base64 encoded
+    ByteBuffer pagingState =
+        ByteBuffer.wrap(new byte[] {0x08, 0x11, 0x1A, 0x1B}); // CBEaGW== base64 encoded
+    Frame frame =
+        new Frame(
+            4,
+            false,
+            10,
+            false,
+            null,
+            Collections.unmodifiableMap(new HashMap<>()),
+            Collections.emptyList(),
+            new Execute(
+                id,
+                metadataId,
+                new QueryOptions(
+                    2,
+                    Collections.emptyList(),
+                    Collections.emptyMap(),
+                    true,
+                    1000,
+                    pagingState,
+                    8,
+                    time,
+                    "myks")));
+
+    String json = writer.writeValueAsString(frame);
+    assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"protocol_version\" : 4,\n"
+                + "  \"beta\" : false,\n"
+                + "  \"stream_id\" : 10,\n"
+                + "  \"tracing_id\" : null,\n"
+                + "  \"custom_payload\" : { },\n"
+                + "  \"warnings\" : [ ],\n"
+                + "  \"message\" : {\n"
+                + "    \"type\" : \"EXECUTE\",\n"
+                + "    \"opcode\" : 10,\n"
+                + "    \"is_response\" : false,\n"
+                + "    \"id\" : \"AQIDBA==\",\n"
+                + "    \"result_metadata_id\" : \"BAIDBA==\",\n"
+                + "    \"options\" : {\n"
+                + "      \"consistency\" : \"TWO\",\n"
+                + "      \"positional_values\" : [ ],\n"
+                + "      \"named_values\" : { },\n"
+                + "      \"skip_metadata\" : true,\n"
+                + "      \"page_size\" : 1000,\n"
+                + "      \"paging_state\" : \"CBEaGw==\",\n"
+                + "      \"serial_consistency\" : \"SERIAL\",\n"
+                + "      \"default_timestamp\" : 1513196542339,\n"
+                + "      \"keyspace\" : \"myks\"\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void testRegisterFrame() throws Exception {
+    Frame frame =
+        new Frame(
+            4,
+            false,
+            10,
+            false,
+            null,
+            Collections.unmodifiableMap(new HashMap<>()),
+            Collections.emptyList(),
+            new Register(Lists.newArrayList("SCHEMA_CHANGE", "TOPOLOGY_CHANGE", "STATUS_CHANGE")));
+
+    String json = writer.writeValueAsString(frame);
+    assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"protocol_version\" : 4,\n"
+                + "  \"beta\" : false,\n"
+                + "  \"stream_id\" : 10,\n"
+                + "  \"tracing_id\" : null,\n"
+                + "  \"custom_payload\" : { },\n"
+                + "  \"warnings\" : [ ],\n"
+                + "  \"message\" : {\n"
+                + "    \"type\" : \"REGISTER\",\n"
+                + "    \"opcode\" : 11,\n"
+                + "    \"is_response\" : false,\n"
+                + "    \"event_types\" : [ \"SCHEMA_CHANGE\", \"TOPOLOGY_CHANGE\", \"STATUS_CHANGE\" ]\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void testBatchFrame() throws Exception {
+    // 0x0807062A = CAcGKg== base64 encoded.
+    List<Object> queriesOrIds =
+        Lists.newArrayList(
+            "select * from tbl", new byte[] {0x8, 0x7, 0x6, 0x2A}, "select * from world");
+    // 0x00 == AA== base64 encoded
+    List<List<ByteBuffer>> values =
+        Lists.newArrayList(
+            Lists.newArrayList(),
+            Lists.newArrayList(ByteBuffer.wrap(new byte[] {0x00})),
+            Lists.newArrayList());
+    Frame frame =
+        new Frame(
+            4,
+            false,
+            10,
+            false,
+            null,
+            Collections.unmodifiableMap(new HashMap<>()),
+            Collections.emptyList(),
+            new Batch((byte) 1, queriesOrIds, values, 2, 10, time, "myks"));
+
+    String json = writer.writeValueAsString(frame);
+    assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"protocol_version\" : 4,\n"
+                + "  \"beta\" : false,\n"
+                + "  \"stream_id\" : 10,\n"
+                + "  \"tracing_id\" : null,\n"
+                + "  \"custom_payload\" : { },\n"
+                + "  \"warnings\" : [ ],\n"
+                + "  \"message\" : {\n"
+                + "    \"type\" : \"BATCH\",\n"
+                + "    \"opcode\" : 13,\n"
+                + "    \"is_response\" : false,\n"
+                + "    \"type\" : \"UNLOGGED\",\n"
+                + "    \"queries_or_ids\" : [ \"select * from tbl\", \"CAcGKg==\", \"select * from world\" ],\n"
+                + "    \"values\" : [ [ ], [ \"AA==\" ], [ ] ],\n"
+                + "    \"consistency\" : \"TWO\",\n"
+                + "    \"serial_consistency\" : \"LOCAL_ONE\",\n"
+                + "    \"default_timestamp\" : 1513196542339,\n"
+                + "    \"keyspace\" : \"myks\"\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void testAuthResponseFrame() throws Exception {
+    Frame frame =
+        new Frame(
+            4,
+            false,
+            10,
+            false,
+            null,
+            Collections.unmodifiableMap(new HashMap<>()),
+            Collections.emptyList(),
+            new AuthResponse(ByteBuffer.wrap(new byte[] {0x00})));
+
+    String json = writer.writeValueAsString(frame);
+    assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"protocol_version\" : 4,\n"
+                + "  \"beta\" : false,\n"
+                + "  \"stream_id\" : 10,\n"
+                + "  \"tracing_id\" : null,\n"
+                + "  \"custom_payload\" : { },\n"
+                + "  \"warnings\" : [ ],\n"
+                + "  \"message\" : {\n"
+                + "    \"type\" : \"AUTHRESPONSE\",\n"
+                + "    \"opcode\" : 15,\n"
+                + "    \"is_response\" : false,\n"
+                + "    \"token\" : \"AA==\"\n"
+                + "  }\n"
+                + "}");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
   <inceptionYear>2017</inceptionYear>
 
   <modules>
+    <module>native-protocol-json</module>
     <module>common</module>
     <module>native-server</module>
     <module>driver-3x</module>


### PR DESCRIPTION
Fixes #6.

Adds a new 'frame' element to /log endpoint json which includes the
fully deserialized json of a native protocol frame.  This should provide
comprehensive details about messages being sent from client.

To accomplish this, added a new project, native-protocol-json that has a
sole purpose of serializing native protocol request frames to json.

Note that serializing from json to native protocol frames is not
implemented, this may be done in the future but isn't useful to us right
now.

Deprecates type, query, consistency_level, serial_consistency_level,
and client_timestamp in /log output as this is all available in the
frame.  These fields will be removed in a future release.