### PR TITLE
[#37] Include some result metadata in noRows response

### DIFF
--- a/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/Prime.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/Prime.java
@@ -27,6 +27,7 @@ import com.datastax.oss.simulacron.common.codec.CodecUtils;
 import com.datastax.oss.simulacron.common.request.Query;
 import com.datastax.oss.simulacron.common.result.ErrorResult;
 import com.datastax.oss.simulacron.common.result.SuccessResult;
+import com.datastax.oss.simulacron.common.result.VoidResult;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -73,6 +74,9 @@ public class Prime extends StubMapping {
     return null;
   }
 
+  private static final RowsMetadata rowMetadataForVoid =
+      new RowsMetadata(new LinkedList<ColumnSpec>(), null, new int[] {0}, null);
+
   public Prepared toPrepared() {
     if (this.primedRequest.when instanceof Query) {
       Query query = (Query) this.primedRequest.when;
@@ -82,6 +86,8 @@ public class Prime extends StubMapping {
         SuccessResult result = (SuccessResult) this.primedRequest.then;
         return new Prepared(
             b.array(), null, fetchRowMetadataForParams(query), fetchRowMetadataForResults(result));
+      } else if (this.primedRequest.then instanceof VoidResult) {
+        return new Prepared(b.array(), null, fetchRowMetadataForParams(query), rowMetadataForVoid);
       } else if (this.primedRequest.then instanceof ErrorResult) {
         return new Prepared(
             b.array(),

--- a/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/PrimeDsl.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/PrimeDsl.java
@@ -136,13 +136,21 @@ public class PrimeDsl {
     return query(query, Collections.singletonList(consistency));
   }
 
+  private static final Map<String, String> noRowsColumnTypes = new HashMap<>();
+
+  static {
+    noRowsColumnTypes.put("fake", "varchar");
+  }
+
+  private static final List<Map<String, Object>> emptyRows = new ArrayList<>();
+
   /**
    * Provides a Rows result with no rows.
    *
    * @return A rows response with no rows.
    */
   public static SuccessResult noRows() {
-    return new SuccessResult(null, null);
+    return new SuccessResult(emptyRows, noRowsColumnTypes);
   }
 
   /**


### PR DESCRIPTION
Fixes #37

To reflect valid ROWS responses, we should always include some result metadata.