### PR TITLE
[#51] Allow nodes to share ip address, use different port

### DIFF
--- a/common/src/test/java/com/datastax/oss/simulacron/common/MessageAssert.java
+++ b/common/src/test/java/com/datastax/oss/simulacron/common/MessageAssert.java
@@ -18,6 +18,7 @@ package com.datastax.oss.simulacron.common;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.oss.protocol.internal.Message;
+import com.datastax.oss.protocol.internal.response.Error;
 import com.datastax.oss.protocol.internal.response.result.Rows;
 import org.assertj.core.api.AbstractAssert;
 
@@ -35,5 +36,12 @@ public class MessageAssert<S extends AbstractAssert<S, A>, A extends Message>
   public RowsAssert isRows() {
     assertThat(actual).isInstanceOf(Rows.class);
     return new RowsAssert((Rows) actual);
+  }
+
+  public MessageAssert isError(int errorCode) {
+    assertThat(actual).isInstanceOf(Error.class);
+    Error e = (Error) actual;
+    assertThat(e.code).isEqualTo(errorCode);
+    return this;
   }
 }

--- a/common/src/test/java/com/datastax/oss/simulacron/common/stubbing/PeerMetadataHandlerTest.java
+++ b/common/src/test/java/com/datastax/oss/simulacron/common/stubbing/PeerMetadataHandlerTest.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.simulacron.common.stubbing;
 
+import static com.datastax.oss.protocol.internal.ProtocolConstants.ErrorCode.INVALID;
 import static com.datastax.oss.simulacron.common.Assertions.assertThat;
 
 import com.datastax.oss.protocol.internal.Frame;
@@ -49,6 +50,7 @@ public class PeerMetadataHandlerTest {
   private static NodeSpec dseNode0;
 
   private PeerMetadataHandler handler = new PeerMetadataHandler();
+  private PeerMetadataHandler handlerV2 = new PeerMetadataHandler(true);
 
   static {
     cluster = ClusterSpec.builder().withName("cluster0").build();
@@ -100,6 +102,7 @@ public class PeerMetadataHandlerTest {
   public void shouldMatchLocalAndPeersQueries() {
     // Should match the following queries.
     assertThat(handler.matches(node0, queryFrame("SELECT * FROM system.peers"))).isTrue();
+    assertThat(handler.matches(node0, queryFrame("SELECT * FROM system.peers_v2"))).isTrue();
     assertThat(handler.matches(node0, queryFrame("select cluster_name from system.local")))
         .isTrue();
     assertThat(handler.matches(node0, queryFrame("SELECT * FROM system.local WHERE key='local'")))
@@ -143,20 +146,24 @@ public class PeerMetadataHandlerTest {
     assertThat(node0Message)
         .isRows()
         .hasRows(1)
-        .hasColumnSpecs(14)
+        .hasColumnSpecs(17)
         .hasColumn(0, 0, "local")
         .hasColumn(0, 1, "COMPLETED")
         .hasColumn(0, 2, ((InetSocketAddress) node0.getAddress()).getAddress())
-        .hasColumn(0, 3, ((InetSocketAddress) node0.getAddress()).getAddress())
-        .hasColumn(0, 4, cluster.getName())
-        .hasColumn(0, 5, "3.2.0")
-        .hasColumn(0, 6, node0.getDataCenter().getName())
-        .hasColumn(0, 7, ((InetSocketAddress) node0.getAddress()).getAddress())
-        .hasColumn(0, 8, "org.apache.cassandra.dht.Murmur3Partitioner")
-        .hasColumn(0, 9, "rack1")
-        .hasColumn(0, 10, "3.0.12")
-        .hasColumn(0, 11, Collections.singleton("0"))
-        .hasColumn(0, 13, PeerMetadataHandler.schemaVersion);
+        .hasColumn(0, 3, ((InetSocketAddress) node0.getAddress()).getPort())
+        .hasColumn(0, 4, ((InetSocketAddress) node0.getAddress()).getAddress())
+        .hasColumn(0, 5, ((InetSocketAddress) node0.getAddress()).getPort())
+        .hasColumn(0, 6, cluster.getName())
+        .hasColumn(0, 7, "3.2.0")
+        .hasColumn(0, 8, node0.getDataCenter().getName())
+        .hasColumn(0, 9, ((InetSocketAddress) node0.getAddress()).getAddress())
+        .hasColumn(0, 10, ((InetSocketAddress) node0.getAddress()).getPort())
+        .hasColumn(0, 11, "org.apache.cassandra.dht.Murmur3Partitioner")
+        .hasColumn(0, 12, "rack1")
+        .hasColumn(0, 13, "3.0.12")
+        .hasColumn(0, 14, Collections.singleton("0"))
+        .hasColumn(0, 15, PeerMetadataHandler.schemaVersion)
+        .hasColumn(0, 16, PeerMetadataHandler.schemaVersion);
   }
 
   @Test
@@ -174,22 +181,26 @@ public class PeerMetadataHandlerTest {
     assertThat(node0Message)
         .isRows()
         .hasRows(1)
-        .hasColumnSpecs(16) // should include dse_version and graph columns
+        .hasColumnSpecs(19) // should include dse_version and graph columns
         .hasColumn(0, 0, "local")
         .hasColumn(0, 1, "COMPLETED")
         .hasColumn(0, 2, InetAddress.getLoopbackAddress())
-        .hasColumn(0, 3, InetAddress.getLoopbackAddress())
-        .hasColumn(0, 4, dseCluster.getName())
-        .hasColumn(0, 5, "3.2.0")
-        .hasColumn(0, 6, dseNode0.getDataCenter().getName())
-        .hasColumn(0, 7, InetAddress.getLoopbackAddress())
-        .hasColumn(0, 8, "org.apache.cassandra.dht.Murmur3Partitioner")
-        .hasColumn(0, 9, "rack1")
-        .hasColumn(0, 10, "3.0.12")
-        .hasColumn(0, 11, Collections.singleton("0"))
-        .hasColumn(0, 13, PeerMetadataHandler.schemaVersion)
-        .hasColumn(0, 14, "5.0.8")
-        .hasColumn(0, 15, true);
+        .hasColumn(0, 3, 9042)
+        .hasColumn(0, 4, InetAddress.getLoopbackAddress())
+        .hasColumn(0, 5, 9042)
+        .hasColumn(0, 6, dseCluster.getName())
+        .hasColumn(0, 7, "3.2.0")
+        .hasColumn(0, 8, dseNode0.getDataCenter().getName())
+        .hasColumn(0, 9, InetAddress.getLoopbackAddress())
+        .hasColumn(0, 10, 9042)
+        .hasColumn(0, 11, "org.apache.cassandra.dht.Murmur3Partitioner")
+        .hasColumn(0, 12, "rack1")
+        .hasColumn(0, 13, "3.0.12")
+        .hasColumn(0, 14, Collections.singleton("0"))
+        .hasColumn(0, 15, PeerMetadataHandler.schemaVersion)
+        .hasColumn(0, 16, PeerMetadataHandler.schemaVersion)
+        .hasColumn(0, 17, "5.0.8")
+        .hasColumn(0, 18, true);
   }
 
   @Test
@@ -207,20 +218,24 @@ public class PeerMetadataHandlerTest {
     assertThat(node0Message)
         .isRows()
         .hasRows(1)
-        .hasColumnSpecs(14)
+        .hasColumnSpecs(17)
         .hasColumn(0, 0, "local")
         .hasColumn(0, 1, "COMPLETED")
         .hasColumn(0, 2, ((InetSocketAddress) node1.getAddress()).getAddress())
-        .hasColumn(0, 3, ((InetSocketAddress) node1.getAddress()).getAddress())
-        .hasColumn(0, 4, cluster.getName())
-        .hasColumn(0, 5, "3.2.0")
-        .hasColumn(0, 6, node1.getDataCenter().getName())
-        .hasColumn(0, 7, ((InetSocketAddress) node1.getAddress()).getAddress())
-        .hasColumn(0, 8, "org.apache.cassandra.dht.Murmur3Partitioner")
-        .hasColumn(0, 9, "rack1")
-        .hasColumn(0, 10, "3.0.12")
-        .hasColumn(0, 11, Collections.singleton("0"))
-        .hasColumn(0, 13, PeerMetadataHandler.schemaVersion);
+        .hasColumn(0, 3, ((InetSocketAddress) node1.getAddress()).getPort())
+        .hasColumn(0, 4, ((InetSocketAddress) node1.getAddress()).getAddress())
+        .hasColumn(0, 5, ((InetSocketAddress) node1.getAddress()).getPort())
+        .hasColumn(0, 6, cluster.getName())
+        .hasColumn(0, 7, "3.2.0")
+        .hasColumn(0, 8, node1.getDataCenter().getName())
+        .hasColumn(0, 9, ((InetSocketAddress) node1.getAddress()).getAddress())
+        .hasColumn(0, 10, ((InetSocketAddress) node1.getAddress()).getPort())
+        .hasColumn(0, 11, "org.apache.cassandra.dht.Murmur3Partitioner")
+        .hasColumn(0, 12, "rack1")
+        .hasColumn(0, 13, "3.0.12")
+        .hasColumn(0, 14, Collections.singleton("0"))
+        .hasColumn(0, 15, PeerMetadataHandler.schemaVersion)
+        .hasColumn(0, 16, PeerMetadataHandler.schemaVersion);
   }
 
   @Test
@@ -256,7 +271,41 @@ public class PeerMetadataHandlerTest {
     Message node0Message = ((MessageResponseAction) node0Action).getMessage();
 
     // should be 199 peers (200 node cluster - 1 for this node).
-    assertThat(node0Message).isRows().hasRows(199).hasColumnSpecs(9);
+    assertThat(node0Message).isRows().hasRows(199).hasColumnSpecs(8);
+  }
+
+  @Test
+  public void shouldHandleQueryAllPeersV2() {
+    // querying for peers should return a row for each other node in the cluster
+    List<Action> node0Actions =
+        handlerV2.getActions(node0, queryFrame("SELECT * FROM system.peers_v2"));
+
+    assertThat(node0Actions).hasSize(1);
+
+    Action node0Action = node0Actions.get(0);
+    assertThat(node0Action).isInstanceOf(MessageResponseAction.class);
+
+    Message node0Message = ((MessageResponseAction) node0Action).getMessage();
+
+    // should be 199 peers (200 node cluster - 1 for this node).
+    assertThat(node0Message).isRows().hasRows(199).hasColumnSpecs(10);
+  }
+
+  @Test
+  public void shouldNotHandleQueryAllPeersV2WhenV2NotSupported() {
+    // querying for peers using v2 should return an error when v2 is not supported.
+    List<Action> node0Actions =
+        handler.getActions(node0, queryFrame("SELECT * FROM system.peers_v2"));
+
+    assertThat(node0Actions).hasSize(1);
+
+    Action node0Action = node0Actions.get(0);
+    assertThat(node0Action).isInstanceOf(MessageResponseAction.class);
+
+    Message node0Message = ((MessageResponseAction) node0Action).getMessage();
+
+    // Should get an invalid error when querying v2 table and v2 is not supported.
+    assertThat(node0Message).isError(INVALID);
   }
 
   @Test
@@ -273,8 +322,8 @@ public class PeerMetadataHandlerTest {
 
     Message node0Message = ((MessageResponseAction) node0Action).getMessage();
 
-    // should be 2 peers and 11 columns (2 extra for dse)
-    assertThat(node0Message).isRows().hasRows(2).hasColumnSpecs(11);
+    // should be 2 peers and 10 columns (2 extra for dse)
+    assertThat(node0Message).isRows().hasRows(2).hasColumnSpecs(10);
   }
 
   @Test
@@ -295,9 +344,9 @@ public class PeerMetadataHandlerTest {
     assertThat(node0Message)
         .isRows()
         .hasRows(1)
-        .hasColumnSpecs(9)
+        .hasColumnSpecs(8)
         .hasColumn(0, 0, InetAddress.getByAddress(new byte[] {127, 0, 11, 17}))
-        .hasColumn(0, 2, "dc1");
+        .hasColumn(0, 1, "dc1");
   }
 
   @Test
@@ -325,9 +374,78 @@ public class PeerMetadataHandlerTest {
     assertThat(node0Message)
         .isRows()
         .hasRows(1)
-        .hasColumnSpecs(9)
+        .hasColumnSpecs(8)
         .hasColumn(0, 0, addr)
-        .hasColumn(0, 2, "dc1");
+        .hasColumn(0, 1, "dc1");
+  }
+
+  @Test
+  public void shouldHandleQuerySpecificPeersV2NamedParameter() throws UnknownHostException {
+    // when peer query is made for a peer in the cluster using named parameters, we should get 1 row
+    // back.
+    InetAddress addr = InetAddress.getByAddress(new byte[] {127, 0, 11, 17});
+    Map<String, ByteBuffer> params = new HashMap<>();
+    params.put("address", ByteBuffer.wrap(addr.getAddress()));
+    ByteBuffer port = ByteBuffer.allocate(4);
+    port.putInt(9042);
+    port.flip();
+    params.put("port", port);
+    QueryOptions queryOptions =
+        new QueryOptions(
+            0, Collections.emptyList(), params, false, 0, null, 10, Long.MIN_VALUE, null);
+    List<Action> node0Actions =
+        handlerV2.getActions(
+            node0,
+            queryFrame(
+                "SELECT * FROM system.peers_v2 WHERE peer = :address AND peer_port = :port",
+                queryOptions));
+
+    assertThat(node0Actions).hasSize(1);
+
+    Action node0Action = node0Actions.get(0);
+    assertThat(node0Action).isInstanceOf(MessageResponseAction.class);
+
+    Message node0Message = ((MessageResponseAction) node0Action).getMessage();
+
+    // should be 1 matching peer
+    assertThat(node0Message)
+        .isRows()
+        .hasRows(1)
+        .hasColumnSpecs(10)
+        .hasColumn(0, 0, addr)
+        .hasColumn(0, 9, 9042);
+  }
+
+  @Test
+  public void shouldNotHandleQuerySpecificPeersV2NamedParameter() throws UnknownHostException {
+    // when peers_v2 query is made, an invalid error should be raised is the handler does not
+    // support v2.
+    InetAddress addr = InetAddress.getByAddress(new byte[] {127, 0, 11, 17});
+    Map<String, ByteBuffer> params = new HashMap<>();
+    params.put("address", ByteBuffer.wrap(addr.getAddress()));
+    ByteBuffer port = ByteBuffer.allocate(4);
+    port.putInt(9042);
+    port.flip();
+    params.put("port", port);
+    QueryOptions queryOptions =
+        new QueryOptions(
+            0, Collections.emptyList(), params, false, 0, null, 10, Long.MIN_VALUE, null);
+    List<Action> node0Actions =
+        handler.getActions(
+            node0,
+            queryFrame(
+                "SELECT * FROM system.peers_v2 WHERE peer = :address AND peer_port = :port",
+                queryOptions));
+
+    assertThat(node0Actions).hasSize(1);
+
+    Action node0Action = node0Actions.get(0);
+    assertThat(node0Action).isInstanceOf(MessageResponseAction.class);
+
+    Message node0Message = ((MessageResponseAction) node0Action).getMessage();
+
+    // should return an error.
+    assertThat(node0Message).isError(INVALID);
   }
 
   @Test
@@ -345,6 +463,6 @@ public class PeerMetadataHandlerTest {
     Message node0Message = ((MessageResponseAction) node0Action).getMessage();
 
     // should be no rows since no peer matched.
-    assertThat(node0Message).isRows().hasRows(0).hasColumnSpecs(9);
+    assertThat(node0Message).isRows().hasRows(0).hasColumnSpecs(8);
   }
 }

--- a/native-server/src/main/java/com/datastax/oss/simulacron/server/AddressResolver.java
+++ b/native-server/src/main/java/com/datastax/oss/simulacron/server/AddressResolver.java
@@ -16,20 +16,9 @@
 package com.datastax.oss.simulacron.server;
 
 import io.netty.channel.local.LocalAddress;
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.ServerSocket;
 import java.net.SocketAddress;
-import java.net.UnknownHostException;
-import java.util.Queue;
 import java.util.UUID;
-import java.util.concurrent.PriorityBlockingQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public interface AddressResolver extends Supplier<SocketAddress> {
 
@@ -42,154 +31,13 @@ public interface AddressResolver extends Supplier<SocketAddress> {
   // different IP range or run multiple instances.
   AddressResolver defaultResolver = new Inet4Resolver();
 
-  AddressResolver localAddressResolver = () -> new LocalAddress(UUID.randomUUID().toString());
-
   /**
-   * A resolver that returns next unused IP address at port 9042. Starts from an input address and
-   * cycles up to the next subnet as it goes, i.e. the order would go something like:
-   *
-   * <p>127.0.0.1, 127.0.0.2 ... 127.0.0.255, 127.0.1.1, 127.0.1.2 and so on.
+   * A resolver that attempts to use every port (after 49152) on an ip before advancing to the next
+   * ip.
    */
-  class Inet4Resolver implements AddressResolver {
+  AddressResolver nodePerPortResolver = new NodePerPortResolver();
 
-    private static final Logger logger = LoggerFactory.getLogger(Inet4Resolver.class);
-    private final AtomicReference<byte[]> ipParts;
-    private static final AtomicBoolean WARNED = new AtomicBoolean();
-    private final int port;
-
-    // Use priority queue so released addresses are sorted by ip address.
-    Queue<InetSocketAddress> releasedAddresses =
-        new PriorityBlockingQueue<>(
-            10,
-            (o1, o2) -> {
-              // Compare ip addresses byte wise, i.e. 127.0.0.1 should come before 127.0.1.2
-              byte[] o1Bytes = o1.getAddress().getAddress();
-              byte[] o2Bytes = o2.getAddress().getAddress();
-
-              // If comparing ipv6 and ipv4 addresses, consider ipv6 greater, this in practice
-              // shouldn't happen.
-              if (o1Bytes.length != o2Bytes.length) {
-                return o1Bytes.length - o2Bytes.length;
-              }
-
-              // compare byte wise.
-              for (int i = 0; i < o1Bytes.length; i++) {
-                if (o1Bytes[i] != o2Bytes[i]) {
-                  return o1Bytes[i] - o2Bytes[i];
-                }
-              }
-
-              // addresses are the same.
-              return 0;
-            });
-
-    public Inet4Resolver(byte[] startingAddress) {
-      this(startingAddress, defaultStartingPort);
-    }
-
-    public Inet4Resolver() {
-      this(defaultStartingIp, defaultStartingPort);
-    }
-
-    public Inet4Resolver(int port) {
-      this(defaultStartingIp, port);
-    }
-
-    public Inet4Resolver(byte startingAddress[], int port) {
-      byte[] ipAddr = new byte[4];
-
-      System.arraycopy(startingAddress, 0, ipAddr, 0, 4);
-      this.ipParts = new AtomicReference<>(ipAddr);
-      this.port = port;
-      checkAddressPresence();
-    }
-
-    private void checkAddressPresence() {
-      if (WARNED.get()) {
-        return;
-      }
-
-      // checks that the OS has 100 local ip addresses.
-      // this check is really only needed for OS X, otherwise return.
-      String osName = System.getProperty("os.name", "none");
-      if (!osName.toLowerCase().startsWith("mac")) {
-        return;
-      }
-      byte[] ipBytes = ipParts.get();
-
-      for (int i = 0; i < 100; i++) {
-        InetAddress inetAddress = inetAddress(ipBytes);
-        try {
-          // Attempt to create socket on that address.
-          new ServerSocket(0, 0, inetAddress);
-        } catch (IOException e) {
-          if (WARNED.compareAndSet(false, true)) {
-            logger.warn(
-                "Detected that {} is not available for use.  "
-                    + "Refer to https://goo.gl/Ru7gUj for information on how to provision IPs on OS X.",
-                inetAddress);
-          }
-          return;
-        }
-        ipBytes = nextAddressBytes(ipBytes);
-      }
-    }
-
-    private InetAddress inetAddress(byte[] ipBytes) {
-      byte[] ipAddr = new byte[4];
-      System.arraycopy(ipBytes, 0, ipAddr, 0, 4);
-
-      InetAddress addr;
-      try {
-        addr = InetAddress.getByAddress(ipAddr);
-      } catch (UnknownHostException uhe) {
-        throw new IllegalArgumentException("Could not create ip address", uhe);
-      }
-      return addr;
-    }
-
-    private byte[] nextAddressBytes(byte[] currentIpBytes) {
-      byte[] newBytes = new byte[4];
-      System.arraycopy(currentIpBytes, 0, newBytes, 0, 4);
-      for (int i = currentIpBytes.length - 1; i > 0; i--) {
-        // roll over ipAddress if we max out the current octet (255)
-        if (newBytes[i] == (byte) 0xFE) {
-          newBytes[i] = 0;
-        } else {
-          ++newBytes[i];
-          break;
-        }
-      }
-      return newBytes;
-    }
-
-    @Override
-    public SocketAddress get() {
-      // If an address was released, reuse it.
-      InetSocketAddress address = releasedAddresses.poll();
-      if (address != null) {
-        return address;
-      } else {
-        // get current address and increment to create next one.
-        // if CAS fails, try again until it works.
-        while (true) {
-          byte[] ref = ipParts.get();
-          InetAddress addr = inetAddress(ref);
-          byte[] next = nextAddressBytes(ref);
-
-          if (ipParts.compareAndSet(ref, next)) {
-            return new InetSocketAddress(addr, this.port);
-          }
-        }
-      }
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public void release(SocketAddress address) {
-      releasedAddresses.offer((InetSocketAddress) address);
-    }
-  }
+  AddressResolver localAddressResolver = () -> new LocalAddress(UUID.randomUUID().toString());
 
   /**
    * Indicates to the resolver that the input address that was previously generated by it is no

--- a/native-server/src/main/java/com/datastax/oss/simulacron/server/AddressResolver.java
+++ b/native-server/src/main/java/com/datastax/oss/simulacron/server/AddressResolver.java
@@ -46,4 +46,27 @@ public interface AddressResolver extends Supplier<SocketAddress> {
    * @param address Address to return.
    */
   default void release(SocketAddress address) {}
+
+  /**
+   * @see com.datastax.oss.simulacron.server.Inet4Resolver
+   * @deprecated replaced by {@link com.datastax.oss.simulacron.server.Inet4Resolver}
+   */
+  @Deprecated
+  class Inet4Resolver extends com.datastax.oss.simulacron.server.Inet4Resolver {
+    public Inet4Resolver(byte[] startingAddress) {
+      super(startingAddress, defaultStartingPort);
+    }
+
+    public Inet4Resolver() {
+      super();
+    }
+
+    public Inet4Resolver(int port) {
+      super(port);
+    }
+
+    public Inet4Resolver(byte startingAddress[], int port) {
+      super(startingAddress, port);
+    }
+  }
 }

--- a/native-server/src/main/java/com/datastax/oss/simulacron/server/Inet4Resolver.java
+++ b/native-server/src/main/java/com/datastax/oss/simulacron/server/Inet4Resolver.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.server;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.SocketAddress;
+import java.net.UnknownHostException;
+import java.util.Queue;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A resolver that returns next unused IP address at port 9042. Starts from an input address and
+ * cycles up to the next subnet as it goes, i.e. the order would go something like:
+ *
+ * <p>127.0.0.1, 127.0.0.2 ... 127.0.0.255, 127.0.1.1, 127.0.1.2 and so on.
+ */
+public class Inet4Resolver implements AddressResolver {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(com.datastax.oss.simulacron.server.Inet4Resolver.class);
+  private final AtomicReference<byte[]> ipParts;
+  private static final AtomicBoolean WARNED = new AtomicBoolean();
+  private final int port;
+
+  // Use priority queue so released addresses are sorted by ip address.
+  private final Queue<InetSocketAddress> releasedAddresses =
+      new PriorityBlockingQueue<>(10, InetSocketAddressComparator.INSTANCE);
+
+  public Inet4Resolver(byte[] startingAddress) {
+    this(startingAddress, defaultStartingPort);
+  }
+
+  public Inet4Resolver() {
+    this(defaultStartingIp, defaultStartingPort);
+  }
+
+  public Inet4Resolver(int port) {
+    this(defaultStartingIp, port);
+  }
+
+  public Inet4Resolver(byte startingAddress[], int port) {
+    byte[] ipAddr = new byte[4];
+
+    System.arraycopy(startingAddress, 0, ipAddr, 0, 4);
+    this.ipParts = new AtomicReference<>(ipAddr);
+    this.port = port;
+    checkAddressPresence(ipAddr, 100);
+  }
+
+  public static void checkAddressPresence(byte ipBytes[], int numberAddresses) {
+    if (WARNED.get()) {
+      return;
+    }
+
+    // checks that the OS has 100 local ip addresses.
+    // this check is really only needed for OS X, otherwise return.
+    String osName = System.getProperty("os.name", "none");
+    if (!osName.toLowerCase().startsWith("mac")) {
+      return;
+    }
+    for (int i = 0; i < numberAddresses; i++) {
+      InetAddress inetAddress = inetAddress(ipBytes);
+      try {
+        // Attempt to create socket on that address.
+        new ServerSocket(0, 0, inetAddress);
+      } catch (IOException e) {
+        if (WARNED.compareAndSet(false, true)) {
+          logger.warn(
+              "Detected that {} is not available for use.  "
+                  + "Refer to https://goo.gl/Ru7gUj for information on how to provision IPs on OS X.",
+              inetAddress);
+        }
+        return;
+      }
+      ipBytes = nextAddressBytes(ipBytes);
+    }
+  }
+
+  public static InetAddress inetAddress(byte[] ipBytes) {
+    byte[] ipAddr = new byte[4];
+    System.arraycopy(ipBytes, 0, ipAddr, 0, 4);
+
+    InetAddress addr;
+    try {
+      addr = InetAddress.getByAddress(ipAddr);
+    } catch (UnknownHostException uhe) {
+      throw new IllegalArgumentException("Could not create ip address", uhe);
+    }
+    return addr;
+  }
+
+  public static byte[] nextAddressBytes(byte[] currentIpBytes) {
+    byte[] newBytes = new byte[4];
+    System.arraycopy(currentIpBytes, 0, newBytes, 0, 4);
+    for (int i = currentIpBytes.length - 1; i > 0; i--) {
+      // roll over ipAddress if we max out the current octet (255)
+      if (newBytes[i] == (byte) 0xFE) {
+        newBytes[i] = 0;
+      } else {
+        ++newBytes[i];
+        break;
+      }
+    }
+    return newBytes;
+  }
+
+  @Override
+  public SocketAddress get() {
+    // If an address was released, reuse it.
+    InetSocketAddress address = releasedAddresses.poll();
+    if (address != null) {
+      return address;
+    } else {
+      // get current address and increment to create next one.
+      // if CAS fails, try again until it works.
+      while (true) {
+        byte[] ref = ipParts.get();
+        InetAddress addr = inetAddress(ref);
+        byte[] next = nextAddressBytes(ref);
+
+        if (ipParts.compareAndSet(ref, next)) {
+          return new InetSocketAddress(addr, this.port);
+        }
+      }
+    }
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void release(SocketAddress address) {
+    releasedAddresses.offer((InetSocketAddress) address);
+  }
+}

--- a/native-server/src/main/java/com/datastax/oss/simulacron/server/InetSocketAddressComparator.java
+++ b/native-server/src/main/java/com/datastax/oss/simulacron/server/InetSocketAddressComparator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.server;
+
+import java.net.InetSocketAddress;
+import java.util.Comparator;
+
+public class InetSocketAddressComparator implements Comparator<InetSocketAddress> {
+
+  public static InetSocketAddressComparator INSTANCE = new InetSocketAddressComparator();
+
+  @Override
+  public int compare(InetSocketAddress o1, InetSocketAddress o2) {
+    // Compare ip addresses byte wise, i.e. 127.0.0.1 should come before 127.0.1.2
+    byte[] o1Bytes = o1.getAddress().getAddress();
+    byte[] o2Bytes = o2.getAddress().getAddress();
+
+    // If comparing ipv6 and ipv4 addresses, consider ipv6 greater, this in practice
+    // shouldn't happen.
+    if (o1Bytes.length != o2Bytes.length) {
+      return o1Bytes.length - o2Bytes.length;
+    }
+
+    // compare byte wise.
+    for (int i = 0; i < o1Bytes.length; i++) {
+      if (o1Bytes[i] != o2Bytes[i]) {
+        return o1Bytes[i] - o2Bytes[i];
+      }
+    }
+
+    // compare by port.
+    return o1.getPort() - o2.getPort();
+  }
+}

--- a/native-server/src/main/java/com/datastax/oss/simulacron/server/NodePerPortResolver.java
+++ b/native-server/src/main/java/com/datastax/oss/simulacron/server/NodePerPortResolver.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.server;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.Queue;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A resolver that returns the next unused port for the current ip address. When we've reached the
+ * end of a port range on an ip, the next ip is used starting with the input starting port. The
+ * order would look something like:
+ *
+ * <p>127.0.0.1:49152,127.0.0.1:49153,...,127.0.0.1:65535,127.0.0.2:49152 and so on.
+ */
+public class NodePerPortResolver implements AddressResolver {
+
+  // the next ip address to use
+  private final AtomicReference<InetSocketAddress> ip;
+  // the port to use at start of ip range
+  private final int startingPortPerIp;
+
+  // Use priority queue so released addresses are sorted by ip address and port.
+  private final Queue<InetSocketAddress> releasedAddresses =
+      new PriorityBlockingQueue<>(10, InetSocketAddressComparator.INSTANCE);
+
+  public NodePerPortResolver() {
+    this(defaultStartingIp, 49152);
+  }
+
+  public NodePerPortResolver(int startingPortPerIp) {
+    this(defaultStartingIp, startingPortPerIp);
+  }
+
+  public NodePerPortResolver(byte startingAddress[], int startingPortPerIp) {
+    byte[] ipAddr = new byte[4];
+
+    System.arraycopy(startingAddress, 0, ipAddr, 0, 4);
+    this.ip =
+        new AtomicReference<>(
+            new InetSocketAddress(Inet4Resolver.inetAddress(ipAddr), startingPortPerIp));
+
+    this.startingPortPerIp = startingPortPerIp;
+
+    Inet4Resolver.checkAddressPresence(ipAddr, 1);
+  }
+
+  @Override
+  public SocketAddress get() {
+    // If an address was released, reuse it.
+    InetSocketAddress address = releasedAddresses.poll();
+    if (address != null) {
+      return address;
+    } else {
+      // get current address and increment to the next one.
+      // if CAS fails try again until it works.
+      while (true) {
+        InetSocketAddress addr = ip.get();
+
+        int port = addr.getPort() + 1;
+
+        InetSocketAddress newAddress;
+        // if we've exhausted ports, move on to next ip, otherwise use next port.
+        if (port > 65535) {
+          newAddress =
+              new InetSocketAddress(
+                  Inet4Resolver.inetAddress(
+                      Inet4Resolver.nextAddressBytes(addr.getAddress().getAddress())),
+                  startingPortPerIp);
+        } else {
+          newAddress = new InetSocketAddress(addr.getAddress(), port);
+        }
+
+        if (ip.compareAndSet(addr, newAddress)) {
+          return addr;
+        }
+      }
+    }
+  }
+}

--- a/native-server/src/test/java/com/datastax/oss/simulacron/server/NodePerPortResolverTest.java
+++ b/native-server/src/test/java/com/datastax/oss/simulacron/server/NodePerPortResolverTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import org.junit.Test;
+
+public class NodePerPortResolverTest {
+
+  @Test
+  public void testNodeAssignedPerPort() {
+    InetAddress startingAddress = Inet4Resolver.inetAddress(AddressResolver.defaultStartingIp);
+    int expectedPort = 1000;
+    AddressResolver resolver = new NodePerPortResolver(expectedPort);
+
+    for (int i = 0; i < 1000; i++) {
+      InetSocketAddress address = (InetSocketAddress) resolver.get();
+      assertThat(address.getAddress()).isEqualTo(startingAddress);
+      assertThat(address.getPort()).isEqualTo(expectedPort++);
+    }
+  }
+
+  @Test
+  public void testShouldCycleIpWhenPortsExhausted() {
+    InetAddress expectedAddress = Inet4Resolver.inetAddress(AddressResolver.defaultStartingIp);
+    int expectedPort = 65530;
+    AddressResolver resolver = new NodePerPortResolver(expectedPort);
+
+    for (int i = 0; i < 1000; i++) {
+      InetSocketAddress address = (InetSocketAddress) resolver.get();
+      assertThat(address.getAddress()).isEqualTo(expectedAddress);
+      assertThat(address.getPort()).isEqualTo(expectedPort++);
+      if (expectedPort == 65536) {
+        expectedPort = 65530;
+        expectedAddress =
+            Inet4Resolver.inetAddress(Inet4Resolver.nextAddressBytes(expectedAddress.getAddress()));
+      }
+    }
+  }
+}

--- a/standalone/src/main/java/com/datastax/oss/simulacron/standalone/CommandLineArguments.java
+++ b/standalone/src/main/java/com/datastax/oss/simulacron/standalone/CommandLineArguments.java
@@ -29,6 +29,13 @@ class CommandLineArguments {
   String ipAddress = "127.0.0.1";
 
   @Parameter(
+    names = {"--starting-port", "-s"},
+    description =
+        "Starting Port to assign Nodes to.  Note that if this is used multiple nodes can be assigned on one IP (which mimics C* 4.0+ peering)"
+  )
+  int startingPort = -1;
+
+  @Parameter(
     names = {"--httpport", "-p"},
     description = "HTTP port to bind on"
   )


### PR DESCRIPTION
Adds a new resolver, `NodePerPortResolver` which allows assigning
multiple nodes on an ip with an increment port number.  This can be used
with `Server.Builder.withMultipleNodesPerIp` to assign multiple nodes to
an interface.  Also accessible by providing a new option
`--starting-port X` to the CLI which if configured enables this mode.

This only works with drivers that support querying the system.peers_v2
table to retrieve rpc port information.

Fixes #51.