### PR TITLE
[#66] Add response coalescer

### DIFF
--- a/native-server/src/main/java/com/datastax/oss/simulacron/server/Server.java
+++ b/native-server/src/main/java/com/datastax/oss/simulacron/server/Server.java
@@ -38,6 +38,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.util.AttributeKey;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timer;
@@ -856,6 +857,7 @@ public final class Server implements AutoCloseable {
         logger.debug("Got new connection {}", channel);
 
         pipeline
+            .addLast(new FlushConsolidationHandler())
             .addLast("decoder", new FrameDecoder(node.getFrameCodec()))
             .addLast("encoder", new FrameEncoder(node.getFrameCodec()))
             .addLast("requestHandler", new RequestHandler(node));


### PR DESCRIPTION
I tested this in few different scenarios. I saw not real performance difference when placing the FlushConsolidationHandler() in different places in the pipeline. It's recommended to place it as high in the pipeline as is practical so that's what I did. 

This drastically reduces the number of packets that are issued by simulacron, under heavy write load, and the results with C* stress looked as good, or better than my homegrown solution. 

Fixes #66