### PR TITLE
Assign unique host_ids to bound nodes

### DIFF
--- a/common/src/main/java/com/datastax/oss/simulacron/common/cluster/AbstractCluster.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/cluster/AbstractCluster.java
@@ -40,7 +40,7 @@ public abstract class AbstractCluster<D extends AbstractDataCenter<?, N>, N exte
       String cassandraVersion,
       String dseVersion,
       Map<String, Object> peerInfo) {
-    super(name, id, cassandraVersion, dseVersion, peerInfo);
+    super(name, id, null, cassandraVersion, dseVersion, peerInfo);
   }
 
   @Override

--- a/common/src/main/java/com/datastax/oss/simulacron/common/cluster/AbstractDataCenter.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/cluster/AbstractDataCenter.java
@@ -43,7 +43,7 @@ public abstract class AbstractDataCenter<C extends AbstractCluster, N extends Ab
       String dseVersion,
       Map<String, Object> peerInfo,
       C parent) {
-    super(name, id, cassandraVersion, dseVersion, peerInfo);
+    super(name, id, null, cassandraVersion, dseVersion, peerInfo);
     this.parent = parent;
     if (this.parent != null) {
       parent.addDataCenter(this);

--- a/common/src/main/java/com/datastax/oss/simulacron/common/cluster/AbstractNode.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/cluster/AbstractNode.java
@@ -26,6 +26,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 public class AbstractNode<C extends AbstractCluster, D extends AbstractDataCenter<C, ?>>
     extends AbstractNodeProperties implements NodeStructure<C, D> {
@@ -41,11 +42,12 @@ public class AbstractNode<C extends AbstractCluster, D extends AbstractDataCente
       SocketAddress address,
       String name,
       Long id,
+      UUID hostId,
       String cassandraVersion,
       String dseVersion,
       Map<String, Object> peerInfo,
       D parent) {
-    super(name, id, cassandraVersion, dseVersion, peerInfo);
+    super(name, id, hostId, cassandraVersion, dseVersion, peerInfo);
     this.address = address;
     this.parent = parent;
     if (this.parent != null) {

--- a/common/src/main/java/com/datastax/oss/simulacron/common/cluster/AbstractNodeProperties.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/cluster/AbstractNodeProperties.java
@@ -18,6 +18,7 @@ package com.datastax.oss.simulacron.common.cluster;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Implementation of {@link NodeProperties} that provides a constructor a implementations for
@@ -33,6 +34,9 @@ public abstract class AbstractNodeProperties implements NodeProperties {
   private final String name;
   private final Long id;
 
+  @JsonProperty("host_id")
+  private final UUID hostId;
+
   @JsonProperty("cassandra_version")
   private final String cassandraVersion;
 
@@ -45,11 +49,13 @@ public abstract class AbstractNodeProperties implements NodeProperties {
   AbstractNodeProperties(
       String name,
       Long id,
+      UUID hostId,
       String cassandraVersion,
       String dseVersion,
       Map<String, Object> peerInfo) {
     this.name = name;
     this.id = id;
+    this.hostId = hostId;
     this.cassandraVersion = cassandraVersion;
     this.dseVersion = dseVersion;
     this.peerInfo = peerInfo;
@@ -63,6 +69,11 @@ public abstract class AbstractNodeProperties implements NodeProperties {
   @Override
   public Long getId() {
     return id;
+  }
+
+  @Override
+  public UUID getHostId() {
+    return hostId;
   }
 
   @Override

--- a/common/src/main/java/com/datastax/oss/simulacron/common/cluster/DataCenterSpec.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/cluster/DataCenterSpec.java
@@ -18,6 +18,7 @@ package com.datastax.oss.simulacron.common.cluster;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
 /** Represents a data center which is a member of a cluster that has nodes belonging to it. */
@@ -48,7 +49,7 @@ public class DataCenterSpec extends AbstractDataCenter<ClusterSpec, NodeSpec> {
    * @return a Builder to create a {@link NodeSpec} in this data center.
    */
   public NodeSpec.Builder addNode() {
-    return new NodeSpec.Builder(this, nodeCounter.getAndIncrement());
+    return new NodeSpec.Builder(this, nodeCounter.getAndIncrement(), UUID.randomUUID());
   }
 
   public static class Builder extends NodePropertiesBuilder<Builder, ClusterSpec> {

--- a/common/src/main/java/com/datastax/oss/simulacron/common/cluster/NodeProperties.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/cluster/NodeProperties.java
@@ -22,6 +22,7 @@ import static java.util.Optional.ofNullable;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.function.Function;
 
 /**
@@ -64,6 +65,13 @@ public interface NodeProperties extends Identifiable {
   /** @return A human readable name for this. */
   @JsonInclude(NON_NULL)
   String getName();
+
+  /**
+   * @return The host id of this if set, otherwise null. The host id uniquely identifies a node, and
+   *     is present in the system.peers and local tables.
+   */
+  @JsonInclude(NON_NULL)
+  UUID getHostId();
 
   /**
    * @return The cassandra version of this if set, otherwise null. The cassandra version is used to

--- a/common/src/main/java/com/datastax/oss/simulacron/common/cluster/NodePropertiesBuilder.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/cluster/NodePropertiesBuilder.java
@@ -17,6 +17,7 @@ package com.datastax.oss.simulacron.common.cluster;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * A base builder to use when defining a {@link NodeProperties} implementation that provides builder
@@ -35,6 +36,7 @@ public abstract class NodePropertiesBuilder<
   String dseVersion;
   String name;
   Long id;
+  UUID hostId;
   Map<String, Object> peerInfo = new HashMap<>();
 
   NodePropertiesBuilder(Class<?> selfType) {
@@ -62,6 +64,7 @@ public abstract class NodePropertiesBuilder<
         .withDSEVersion(toCopy.getDSEVersion())
         .withName(toCopy.getName())
         .withId(toCopy.getId())
+        .withHostId(toCopy.getHostId())
         .withPeerInfo(toCopy.getPeerInfo());
   }
 
@@ -82,6 +85,11 @@ public abstract class NodePropertiesBuilder<
 
   public S withId(Long id) {
     this.id = id;
+    return myself;
+  }
+
+  public S withHostId(UUID hostId) {
+    this.hostId = hostId;
     return myself;
   }
 

--- a/common/src/main/java/com/datastax/oss/simulacron/common/cluster/NodeSpec.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/cluster/NodeSpec.java
@@ -18,6 +18,7 @@ package com.datastax.oss.simulacron.common.cluster;
 import java.net.SocketAddress;
 import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Represents a {@link NodeSpec} which may belong to a cluster (via a data center relationship) or
@@ -30,18 +31,19 @@ public class NodeSpec extends AbstractNode<ClusterSpec, DataCenterSpec> {
 
   NodeSpec() {
     // Default constructor for jackson deserialization.
-    this(null, null, null, null, null, Collections.emptyMap(), null);
+    this(null, null, null, null, null, null, Collections.emptyMap(), null);
   }
 
   public NodeSpec(
       SocketAddress address,
       String name,
       Long id,
+      UUID hostId,
       String cassandraVersion,
       String dseVersion,
       Map<String, Object> peerInfo,
       DataCenterSpec parent) {
-    super(address, name, id, cassandraVersion, dseVersion, peerInfo, parent);
+    super(address, name, id, hostId, cassandraVersion, dseVersion, peerInfo, parent);
   }
 
   /**
@@ -51,16 +53,17 @@ public class NodeSpec extends AbstractNode<ClusterSpec, DataCenterSpec> {
    * @return Builder for creating {@link NodeSpec}
    */
   public static Builder builder() {
-    return new Builder(null, null);
+    return new Builder(null, null, null);
   }
 
   public static class Builder extends NodePropertiesBuilder<Builder, DataCenterSpec> {
 
     private SocketAddress address = null;
 
-    Builder(DataCenterSpec parent, Long id) {
+    Builder(DataCenterSpec parent, Long id, UUID hostId) {
       super(Builder.class, parent);
       this.id = id;
+      this.hostId = hostId;
     }
 
     /**
@@ -76,7 +79,8 @@ public class NodeSpec extends AbstractNode<ClusterSpec, DataCenterSpec> {
 
     /** @return Constructs a {@link NodeSpec} from this builder. Can be called multiple times. */
     public NodeSpec build() {
-      return new NodeSpec(address, name, id, cassandraVersion, dseVersion, peerInfo, parent);
+      return new NodeSpec(
+          address, name, id, hostId, cassandraVersion, dseVersion, peerInfo, parent);
     }
   }
 }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/PeerMetadataHandler.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/PeerMetadataHandler.java
@@ -221,7 +221,7 @@ public class PeerMetadataHandler extends StubMapping implements InternalStubMapp
             CodecUtils.encodePeerInfo(node, mapper.ascii::encode, "rack", "rack1"),
             mapper.ascii.encode(node.resolveCassandraVersion()),
             tokenCodec.encode(resolveTokens(node)),
-            mapper.uuid.encode(node.resolvePeerInfo("host_id", schemaVersion)),
+            mapper.uuid.encode(node.getHostId()),
             mapper.uuid.encode(schemaVersion));
 
     if (node.resolveDSEVersion() != null) {
@@ -268,7 +268,7 @@ public class PeerMetadataHandler extends StubMapping implements InternalStubMapp
                           mapper.varchar.encode(
                               n.resolvePeerInfo("release_version", n.resolveCassandraVersion())),
                           tokenCodec.encode(resolveTokens(n)),
-                          mapper.uuid.encode(n.resolvePeerInfo("host_id", schemaVersion)),
+                          mapper.uuid.encode(n.getHostId()),
                           mapper.uuid.encode(n.resolvePeerInfo("schema_version", schemaVersion)));
 
                   if (isV2) {

--- a/common/src/test/java/com/datastax/oss/simulacron/common/cluster/NodeTest.java
+++ b/common/src/test/java/com/datastax/oss/simulacron/common/cluster/NodeTest.java
@@ -21,8 +21,11 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import org.junit.Test;
 
 public class NodeTest {
@@ -48,6 +51,7 @@ public class NodeTest {
   @Test
   public void testShouldInheritBuilderProperties() {
     long id = 12L;
+    UUID hostId = UUID.randomUUID();
     InetSocketAddress address = new InetSocketAddress(InetAddress.getLoopbackAddress(), 9042);
     String version = "1.2.19";
     String name = "node0";
@@ -56,6 +60,7 @@ public class NodeTest {
     NodeSpec node =
         NodeSpec.builder()
             .withId(id)
+            .withHostId(hostId)
             .withAddress(address)
             .withCassandraVersion(version)
             .withName(name)
@@ -67,6 +72,7 @@ public class NodeTest {
     expectedPeerInfo.put("goodbye", "world");
 
     assertThat(node.getId()).isEqualTo(id);
+    assertThat(node.getHostId()).isEqualTo(hostId);
     assertThat(node.getAddress()).isEqualTo(address);
     assertThat(node.getCassandraVersion()).isEqualTo(version);
     assertThat(node.getName()).isEqualTo(name);
@@ -111,5 +117,23 @@ public class NodeTest {
 
     // Address should not be copied.
     assertThat(node2.getAddress()).isNull();
+  }
+
+  @Test
+  public void testShouldAssignUniqueHostIds() {
+    ClusterSpec cluster = ClusterSpec.builder().build();
+    DataCenterSpec dataCenter0 = cluster.addDataCenter().build();
+    NodeSpec node00 = dataCenter0.addNode().build();
+    NodeSpec node01 = dataCenter0.addNode().build();
+    DataCenterSpec dataCenter1 = cluster.addDataCenter().build();
+    NodeSpec node10 = dataCenter1.addNode().build();
+    NodeSpec node11 = dataCenter1.addNode().build();
+
+    Set<UUID> hostIds = new HashSet<>();
+    hostIds.add(node00.getHostId());
+    hostIds.add(node01.getHostId());
+    hostIds.add(node10.getHostId());
+    hostIds.add(node11.getHostId());
+    assertThat(hostIds).hasSize(4);
   }
 }

--- a/common/src/test/java/com/datastax/oss/simulacron/common/cluster/ObjectMapperHolderTest.java
+++ b/common/src/test/java/com/datastax/oss/simulacron/common/cluster/ObjectMapperHolderTest.java
@@ -46,10 +46,14 @@ public class ObjectMapperHolderTest {
     String json = mapper.writeValueAsString(cluster);
 
     String expectedJson =
-        "{\"name\":\"cluster1\",\"dse_version\":\"5.1.0\",\"data_centers\":["
-            + "{\"name\":\"dc1\",\"id\":0,\"nodes\":[{\"name\":\"node1\",\"id\":0,\"active_connections\":0}],\"active_connections\":0},"
-            + "{\"name\":\"dc2\",\"id\":1,\"nodes\":[{\"name\":\"node1\",\"id\":0,\"active_connections\":0},{\"name\":\"node2\",\"id\":1,\"active_connections\":0}],\"active_connections\":0}"
-            + "],\"active_connections\":0}";
+        String.format(
+            "{\"name\":\"cluster1\",\"dse_version\":\"5.1.0\",\"data_centers\":["
+                + "{\"name\":\"dc1\",\"id\":0,\"nodes\":[{\"name\":\"node1\",\"id\":0,\"host_id\":\"%s\",\"active_connections\":0}],\"active_connections\":0},"
+                + "{\"name\":\"dc2\",\"id\":1,\"nodes\":[{\"name\":\"node1\",\"id\":0,\"host_id\":\"%s\",\"active_connections\":0},{\"name\":\"node2\",\"id\":1,\"host_id\":\"%s\",\"active_connections\":0}],\"active_connections\":0}"
+                + "],\"active_connections\":0}",
+            cluster.node(0, 0).getHostId(),
+            cluster.node(1, 0).getHostId(),
+            cluster.node(1, 1).getHostId());
     assertThat(json).isEqualTo(expectedJson);
 
     ClusterSpec cluster2 = mapper.readValue(json, ClusterSpec.class);
@@ -74,10 +78,12 @@ public class ObjectMapperHolderTest {
     String json = mapper.writeValueAsString(cluster);
 
     String expectedJson =
-        "{\"data_centers\":[{\"name\":\"0\",\"id\":0,\"nodes\":["
-            + "{\"name\":\"0\",\"id\":0,\"address\":\"127.0.0.1:9042\",\"active_connections\":0},"
-            + "{\"name\":\"1\",\"id\":1,\"address\":\"127.0.0.2:9042\",\"active_connections\":0}"
-            + "],\"active_connections\":0}],\"active_connections\":0}";
+        String.format(
+            "{\"data_centers\":[{\"name\":\"0\",\"id\":0,\"nodes\":["
+                + "{\"name\":\"0\",\"id\":0,\"address\":\"127.0.0.1:9042\",\"host_id\":\"%s\",\"active_connections\":0},"
+                + "{\"name\":\"1\",\"id\":1,\"address\":\"127.0.0.2:9042\",\"host_id\":\"%s\",\"active_connections\":0}"
+                + "],\"active_connections\":0}],\"active_connections\":0}",
+            cluster.node(0, 0).getHostId(), cluster.node(0, 1).getHostId());
     assertThat(json).isEqualTo(expectedJson);
 
     ClusterSpec cluster2 = mapper.readValue(json, ClusterSpec.class);

--- a/common/src/test/java/com/datastax/oss/simulacron/common/stubbing/PeerMetadataHandlerTest.java
+++ b/common/src/test/java/com/datastax/oss/simulacron/common/stubbing/PeerMetadataHandlerTest.java
@@ -162,7 +162,7 @@ public class PeerMetadataHandlerTest {
         .hasColumn(0, 12, "rack1")
         .hasColumn(0, 13, "3.0.12")
         .hasColumn(0, 14, Collections.singleton("0"))
-        .hasColumn(0, 15, PeerMetadataHandler.schemaVersion)
+        .hasColumn(0, 15, node0.getHostId())
         .hasColumn(0, 16, PeerMetadataHandler.schemaVersion);
   }
 
@@ -197,7 +197,7 @@ public class PeerMetadataHandlerTest {
         .hasColumn(0, 12, "rack1")
         .hasColumn(0, 13, "3.0.12")
         .hasColumn(0, 14, Collections.singleton("0"))
-        .hasColumn(0, 15, PeerMetadataHandler.schemaVersion)
+        .hasColumn(0, 15, dseNode0.getHostId())
         .hasColumn(0, 16, PeerMetadataHandler.schemaVersion)
         .hasColumn(0, 17, "5.0.8")
         .hasColumn(0, 18, true);
@@ -234,7 +234,7 @@ public class PeerMetadataHandlerTest {
         .hasColumn(0, 12, "rack1")
         .hasColumn(0, 13, "3.0.12")
         .hasColumn(0, 14, Collections.singleton("0"))
-        .hasColumn(0, 15, PeerMetadataHandler.schemaVersion)
+        .hasColumn(0, 15, node1.getHostId())
         .hasColumn(0, 16, PeerMetadataHandler.schemaVersion);
   }
 

--- a/native-server/src/main/java/com/datastax/oss/simulacron/server/BoundNode.java
+++ b/native-server/src/main/java/com/datastax/oss/simulacron/server/BoundNode.java
@@ -78,6 +78,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -163,6 +164,7 @@ public class BoundNode extends AbstractNode<BoundCluster, BoundDataCenter>
         address,
         delegate.getName(),
         delegate.getId() != null ? delegate.getId() : 0,
+        delegate.getHostId() != null ? delegate.getHostId() : UUID.randomUUID(),
         delegate.getCassandraVersion(),
         delegate.getDSEVersion(),
         peerInfo,


### PR DESCRIPTION
With [JAVA-2165](https://datastax-oss.atlassian.net/browse/JAVA-2165), the Java driver will now index its node metadata by `host_id`. This won't work with Simulacron's default behavior, which is to assign the same UUID to every node. We need unique ids.

This is the simplest way to address the issue. It fixes my problem but is a bit fragile if the user overrides the key manually, or the whole map by calling `withPeerInfo(Map)`. Maybe we should check that a `host_id` is always present, or even promote it to a top-level property like `withCassandraVersion`. 