### PR TITLE
[#71] Default starting IP should be 127.0.0.1

### DIFF
--- a/native-server/src/main/java/com/datastax/oss/simulacron/server/AddressResolver.java
+++ b/native-server/src/main/java/com/datastax/oss/simulacron/server/AddressResolver.java
@@ -22,7 +22,7 @@ import java.util.function.Supplier;
 
 public interface AddressResolver extends Supplier<SocketAddress> {
 
-  byte[] defaultStartingIp = new byte[] {127, 0, 1, 1};
+  byte[] defaultStartingIp = new byte[] {127, 0, 0, 1};
   int defaultStartingPort = 9042;
 
   // TODO: make this configurable when needed.  For now we'll just use incrementing IPs from


### PR DESCRIPTION
For some reason the default starting ip address was 127.0.1.1.

This might have been to prevent conflicting with a local C* running,
but for usability, especially on OS X, we should default to 127.0.0.1.

The standalone jar defaults to 127.0.0.1, so this makes using native
server directly consistent with the web-based mode.

Fixes #71