### PR TITLE
[#82] Update PeerMetadataHandler to support new cluster name query

### DIFF
--- a/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/PeerMetadataHandler.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/PeerMetadataHandler.java
@@ -62,7 +62,7 @@ public class PeerMetadataHandler extends StubMapping implements InternalStubMapp
 
   private static final Pattern queryClusterName =
       Pattern.compile(
-          "select cluster_name from system.local( where key='local')?", Pattern.CASE_INSENSITIVE);
+          "SELECT cluster_name FROM system.local( WHERE key='local')?", Pattern.CASE_INSENSITIVE);
   private static final RowsMetadata queryClusterNameMetadata;
 
   static {

--- a/common/src/test/java/com/datastax/oss/simulacron/common/stubbing/PeerMetadataHandlerTest.java
+++ b/common/src/test/java/com/datastax/oss/simulacron/common/stubbing/PeerMetadataHandlerTest.java
@@ -259,6 +259,27 @@ public class PeerMetadataHandlerTest {
   }
 
   @Test
+  public void shouldHandleQueryClusterName2() {
+    // querying the local table for cluster_name should return ClusterSpec.getName()
+    List<Action> node0Actions =
+        handler.getActions(
+            node0, queryFrame("select cluster_name from system.local where key='local'"));
+
+    assertThat(node0Actions).hasSize(1);
+
+    Action node0Action = node0Actions.get(0);
+    assertThat(node0Action).isInstanceOf(MessageResponseAction.class);
+
+    Message node0Message = ((MessageResponseAction) node0Action).getMessage();
+
+    assertThat(node0Message)
+        .isRows()
+        .hasRows(1)
+        .hasColumnSpecs(1)
+        .hasColumn(0, 0, cluster.getName());
+  }
+
+  @Test
   public void shouldHandleQueryAllPeers() {
     // querying for peers should return a row for each other node in the cluster
     List<Action> node0Actions = handler.getActions(node0, queryFrame("SELECT * FROM system.peers"));


### PR DESCRIPTION
The change below:

https://github.com/datastax/java-driver/commit/85f2ced0584867c76df3024bc97de9f0038c0908#diff-8dd2643235bd91722e75bdd299d4ca8c

Was released in drivers OSS 3.7.2 and DSE 1.8.2. We need to update
`PeerMetadataHandler` accordingly.