### PR TITLE
[#84] Remove github-release-plugin

### DIFF
--- a/standalone/pom.xml
+++ b/standalone/pom.xml
@@ -87,42 +87,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>de.jutzig</groupId>
-            <artifactId>github-release-plugin</artifactId>
-            <version>1.2.0</version>
-            <configuration>
-              <prerelease>true</prerelease>
-              <draft>true</draft>
-              <repositoryId>datastax/simulacron</repositoryId>
-              <tag>${project.version}</tag>
-              <fileSets>
-                <fileSet>
-                  <directory>${project.build.directory}</directory>
-                  <includes>
-                    <include>simulacron-standalone-${project.version}.jar</include>
-                  </includes>
-                </fileSet>
-              </fileSets>
-            </configuration>
-            <executions>
-              <execution>
-                <id>release-at-deploy</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>release</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
The github-release-plugin does not handle 2-factor Auth so it is
impossible for those with 2FA enabled to release Simulacron.

This commit simply gets rid of this plugin.