### PR TITLE
[fixes #86] PeerMetadataHandler should handle query variants

### DIFF
--- a/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/PeerMetadataHandler.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/PeerMetadataHandler.java
@@ -61,7 +61,7 @@ public class PeerMetadataHandler extends StubMapping implements InternalStubMapp
 
   private static final Pattern queryClusterName =
       Pattern.compile(
-          "SELECT\\s+cluster_name\\s+FROM\\s+system\\.local(\\s+WHERE\\s+key\\s*=\\s*'local')?",
+          "SELECT\\s+cluster_name\\s+FROM\\s+system\\.local(\\s+WHERE\\s+key\\s*=\\s*'local')?\\s*;?\\s*",
           Pattern.CASE_INSENSITIVE);
   private static final RowsMetadata queryClusterNameMetadata;
 
@@ -73,25 +73,25 @@ public class PeerMetadataHandler extends StubMapping implements InternalStubMapp
   }
 
   private static final Pattern queryPeers =
-      Pattern.compile("SELECT\\s+(.*)\\s+FROM\\s+system\\.(peers\\S*)", Pattern.CASE_INSENSITIVE);
+      Pattern.compile(
+          "\\s*SELECT\\s+(.*)\\s+FROM\\s+system\\.(peers\\S*)\\s*;?\\s*", Pattern.CASE_INSENSITIVE);
   private static final Pattern queryLocal =
       Pattern.compile(
-          "SELECT\\s+(.*)\\s+FROM\\s+system\\.local(\\s+WHERE\\s+key\\s*=\\s*'local')?",
+          "\\s*SELECT\\s+(.*)\\s+FROM\\s+system\\.local(\\s+WHERE\\s+key\\s*=\\s*'local')?\\s*;?\\s*",
           Pattern.CASE_INSENSITIVE);
   private static final Pattern queryPeersWithAddr =
       Pattern.compile(
-          "SELECT\\s+\\*\\s+FROM\\s+system\\.peers\\s+WHERE\\s+peer\\s*=\\s*'(.*)'",
+          "\\s*SELECT\\s+\\*\\s+FROM\\s+system\\.peers\\s+WHERE\\s+peer\\s*=\\s*'(.*)'\\s*;?\\s*",
           Pattern.CASE_INSENSITIVE);
 
   // query the java driver makes when refreshing node (i.e. after it comes back up)
   private static final Pattern queryPeerWithNamedParam =
       Pattern.compile(
-          "SELECT\\s+\\*\\s+FROM\\s+system\\.peers\\s+" + "WHERE\\s+peer\\s*=\\s*:address",
+          "\\s*SELECT\\s+\\*\\s+FROM\\s+system\\.peers\\s+WHERE\\s+peer\\s*=\\s*:address\\s*;?\\s*",
           Pattern.CASE_INSENSITIVE);
   private static final Pattern queryPeerV2WithNamedParam =
       Pattern.compile(
-          "SELECT\\s+\\*\\s+FROM\\s+system\\.peers_v2\\s+"
-              + "WHERE\\s+peer\\s*=\\s*:address\\s+AND\\s+peer_port\\s*=\\s*:port",
+          "\\s*SELECT\\s+\\*\\s+FROM\\s+system\\.peers_v2\\s+WHERE\\s+peer\\s*=\\s*:address\\s+AND\\s+peer_port\\s*=\\s*:port\\s*;?\\s*",
           Pattern.CASE_INSENSITIVE);
 
   private final boolean supportsV2;

--- a/common/src/test/java/com/datastax/oss/simulacron/common/stubbing/PeerMetadataHandlerTest.java
+++ b/common/src/test/java/com/datastax/oss/simulacron/common/stubbing/PeerMetadataHandlerTest.java
@@ -32,6 +32,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -241,42 +242,28 @@ public class PeerMetadataHandlerTest {
   @Test
   public void shouldHandleQueryClusterName() {
     // querying the local table for cluster_name should return ClusterSpec.getName()
-    List<Action> node0Actions =
-        handler.getActions(node0, queryFrame("select cluster_name from system.local"));
+    List<String> queries =
+        Arrays.asList(
+            "SELECT cluster_name FROM system.local",
+            "select cluster_name from system.local where key='local'",
+            "select cluster_name from system.local where key = 'local'");
 
-    assertThat(node0Actions).hasSize(1);
+    for (String query : queries) {
+      List<Action> node0Actions = handler.getActions(node0, queryFrame(query));
 
-    Action node0Action = node0Actions.get(0);
-    assertThat(node0Action).isInstanceOf(MessageResponseAction.class);
+      assertThat(node0Actions).hasSize(1);
 
-    Message node0Message = ((MessageResponseAction) node0Action).getMessage();
+      Action node0Action = node0Actions.get(0);
+      assertThat(node0Action).isInstanceOf(MessageResponseAction.class);
 
-    assertThat(node0Message)
-        .isRows()
-        .hasRows(1)
-        .hasColumnSpecs(1)
-        .hasColumn(0, 0, cluster.getName());
-  }
+      Message node0Message = ((MessageResponseAction) node0Action).getMessage();
 
-  @Test
-  public void shouldHandleQueryClusterName2() {
-    // querying the local table for cluster_name should return ClusterSpec.getName()
-    List<Action> node0Actions =
-        handler.getActions(
-            node0, queryFrame("select cluster_name from system.local where key='local'"));
-
-    assertThat(node0Actions).hasSize(1);
-
-    Action node0Action = node0Actions.get(0);
-    assertThat(node0Action).isInstanceOf(MessageResponseAction.class);
-
-    Message node0Message = ((MessageResponseAction) node0Action).getMessage();
-
-    assertThat(node0Message)
-        .isRows()
-        .hasRows(1)
-        .hasColumnSpecs(1)
-        .hasColumn(0, 0, cluster.getName());
+      assertThat(node0Message)
+          .isRows()
+          .hasRows(1)
+          .hasColumnSpecs(1)
+          .hasColumn(0, 0, cluster.getName());
+    }
   }
 
   @Test


### PR DESCRIPTION
Some common peer queries may have variants, e.g. a WHERE clause can be
`WHERE key = 'local'` or `where key='local'`.

This commit amends PeerMetadataHandler to handle case insensitiveness
and also optional whitespaces in queries.