### PR TITLE
Support pause/resume reading on Connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ See the [Java API User's Guide](doc/java_api) for using this API.
 
 ## License
 
-Copyright 2017, DataStax
+© DataStax, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/http-server/src/main/resources/webroot/swagger/swagger.yaml
+++ b/http-server/src/main/resources/webroot/swagger/swagger.yaml
@@ -38,6 +38,8 @@ tags:
     description: Close an individual connection by ip address and port
   - name: listener
     description: Enable and disable node's capability to accept new connections
+  - name: pause-reads
+    description: Pause and resume reading on node connections.
 paths:
   /cluster:
     post:
@@ -1741,6 +1743,187 @@ paths:
           description: connections will be rejected
         '500':
           description: Internal server error
+
+  '/pause-reads/{clusterId}':
+    put:
+      tags:
+        - pause-reads
+      summary: pause the connections to the cluster
+      operationId: pauseConnectionsByCluster
+      produces:
+        - application/json
+      parameters:
+        - name: clusterId
+          in: path
+          description: Id or name of the cluster
+          required: true
+          type: string
+          example: "0"
+      responses:
+        '200':
+          description: paused connections
+          schema:
+            $ref: '#/definitions/ClusterConnectionReport'
+        '404':
+          description: Cluster not found
+        '500':
+          description: Internal server error
+    delete:
+      tags:
+        - pause-reads
+      summary: resume the connections to the cluster
+      operationId: resumeConnectionsByCluster
+      produces:
+        - application/json
+      parameters:
+        - name: clusterId
+          in: path
+          description: Id or name of the cluster
+          required: true
+          type: string
+          example: "0"
+      responses:
+        '200':
+          description: paused connections
+          schema:
+            $ref: '#/definitions/ClusterConnectionReport'
+        '404':
+          description: Cluster not found
+        '500':
+          description: Internal server error
+
+  '/pause-reads/{clusterId}/{dataCenterId}':
+    put:
+      tags:
+        - pause-reads
+      summary: pause the connections to the datacenter
+      operationId: pauseConnectionsByDc
+      produces:
+        - application/json
+      parameters:
+        - name: clusterId
+          in: path
+          description: Id or name of the cluster
+          required: true
+          type: string
+          example: "0"
+        - name: dataCenterId
+          in: path
+          description: Id or name of the datacenter
+          required: true
+          type: string
+          example: "0"
+      responses:
+        '200':
+          description: paused connections
+          schema:
+            $ref: '#/definitions/DataCenterConnectionReport'
+        '404':
+          description: Cluster not found
+        '500':
+          description: Internal server error
+    delete:
+      tags:
+        - pause-reads
+      summary: resume the connections to the cluster
+      operationId: resumeConnectionsByCluster
+      produces:
+        - application/json
+      parameters:
+        - name: clusterId
+          in: path
+          description: Id or name of the cluster
+          required: true
+          type: string
+          example: "0"
+        - name: dataCenterId
+          in: path
+          description: Id or name of the datacenter
+          required: true
+          type: string
+          example: "0"
+      responses:
+        '200':
+          description: paused connections
+          schema:
+            $ref: '#/definitions/DataCenterConnectionReport'
+        '404':
+          description: Cluster not found
+        '500':
+          description: Internal server error
+
+  '/pause-reads/{clusterId}/{dataCenterId}/{nodeId}':
+    put:
+      tags:
+        - pause-reads
+      summary: pause the connections to the datacenter
+      operationId: pauseConnectionsByDc
+      produces:
+        - application/json
+      parameters:
+        - name: clusterId
+          in: path
+          description: Id or name of the cluster
+          required: true
+          type: string
+          example: "0"
+        - name: dataCenterId
+          in: path
+          description: Id or name of the datacenter
+          required: true
+          type: string
+          example: "0"
+        - name: nodeId
+          in: path
+          description: Id or name of the node
+          required: true
+          type: string
+          example: "0"
+      responses:
+        '200':
+          description: paused connections
+          schema:
+            $ref: '#/definitions/DataCenterConnectionReport'
+        '404':
+          description: Cluster not found
+        '500':
+          description: Internal server error
+    delete:
+      tags:
+        - pause-reads
+      summary: resume the connections to the cluster
+      operationId: resumeConnectionsByCluster
+      produces:
+        - application/json
+      parameters:
+        - name: clusterId
+          in: path
+          description: Id or name of the cluster
+          required: true
+          type: string
+          example: "0"
+        - name: dataCenterId
+          in: path
+          description: Id or name of the datacenter
+          required: true
+          type: string
+          example: "0"
+        - name: nodeId
+          in: path
+          description: Id or name of the node
+          required: true
+          type: string
+          example: "0"
+      responses:
+        '200':
+          description: paused connections
+          schema:
+            $ref: '#/definitions/NodeConnectionReport'
+        '404':
+          description: Cluster not found
+        '500':
+          description: Internal server error
+
 definitions:
   DataType:
     type: string

--- a/native-server/src/main/java/com/datastax/oss/simulacron/server/BoundCluster.java
+++ b/native-server/src/main/java/com/datastax/oss/simulacron/server/BoundCluster.java
@@ -130,6 +130,18 @@ public class BoundCluster extends AbstractCluster<BoundDataCenter, BoundNode>
     return failedFuture;
   }
 
+  @Override
+  public ClusterConnectionReport pauseRead() {
+    this.getNodes().forEach(BoundNode::pauseRead);
+    return getConnections();
+  }
+
+  @Override
+  public ClusterConnectionReport resumeRead() {
+    this.getNodes().forEach(BoundNode::resumeRead);
+    return getConnections();
+  }
+
   /**
    * Returns a QueryLogReport that contains all the logs for this cluster
    *

--- a/native-server/src/main/java/com/datastax/oss/simulacron/server/BoundDataCenter.java
+++ b/native-server/src/main/java/com/datastax/oss/simulacron/server/BoundDataCenter.java
@@ -144,6 +144,18 @@ public class BoundDataCenter extends AbstractDataCenter<BoundCluster, BoundNode>
     return failedFuture;
   }
 
+  @Override
+  public DataCenterConnectionReport pauseRead() {
+    this.getNodes().forEach(BoundNode::pauseRead);
+    return getConnections();
+  }
+
+  @Override
+  public DataCenterConnectionReport resumeRead() {
+    this.getNodes().forEach(BoundNode::resumeRead);
+    return getConnections();
+  }
+
   /**
    * Returns a QueryLogReport that contains filtered logs for this datacenter
    *

--- a/native-server/src/main/java/com/datastax/oss/simulacron/server/BoundNode.java
+++ b/native-server/src/main/java/com/datastax/oss/simulacron/server/BoundNode.java
@@ -625,6 +625,18 @@ public class BoundNode extends AbstractNode<BoundCluster, BoundDataCenter>
     return closeChannelGroup(this.clientChannelGroup, closeType).thenApply(v -> report);
   }
 
+  @Override
+  public NodeConnectionReport pauseRead() {
+    this.clientChannelGroup.forEach(c -> c.config().setAutoRead(false));
+    return getConnections();
+  }
+
+  @Override
+  public NodeConnectionReport resumeRead() {
+    this.clientChannelGroup.forEach(c -> c.config().setAutoRead(true));
+    return getConnections();
+  }
+
   private static CompletableFuture<Void> closeChannelGroup(
       ChannelGroup channelGroup, CloseType closeType) {
     switch (closeType) {

--- a/native-server/src/main/java/com/datastax/oss/simulacron/server/BoundTopic.java
+++ b/native-server/src/main/java/com/datastax/oss/simulacron/server/BoundTopic.java
@@ -108,6 +108,20 @@ public interface BoundTopic<C extends ConnectionReport, Q extends QueryLogReport
    */
   CompletionStage<C> closeConnectionAsync(SocketAddress connection, CloseType type);
 
+  /**
+   * Pauses reading on all connections.
+   *
+   * @return report for the connections
+   */
+  C pauseRead();
+
+  /**
+   * Resume reading on all connections.
+   *
+   * @return report for the connections
+   */
+  C resumeRead();
+
   /** @return All nodes belonging to this topic. */
   @JsonIgnore
   Collection<BoundNode> getNodes();


### PR DESCRIPTION
Fixes #90.

Not a fan of `/pause-reads/` name for the route but couldn't think of a better name.