### PR TITLE
Fix null pointer errors in protocol v5 when using prepared statements

### DIFF
--- a/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/Prime.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/stubbing/Prime.java
@@ -80,18 +80,28 @@ public class Prime extends StubMapping {
   public Prepared toPrepared() {
     if (this.primedRequest.when instanceof Query) {
       Query query = (Query) this.primedRequest.when;
+
       ByteBuffer b = ByteBuffer.allocate(4);
       b.putInt(query.getQueryId());
+
+      ByteBuffer bResult = ByteBuffer.allocate(4);
+      bResult.putInt(
+          ~query.getQueryId()); // use bitwise complement of query id for result metadata id
+
       if (this.primedRequest.then instanceof SuccessResult) {
         SuccessResult result = (SuccessResult) this.primedRequest.then;
         return new Prepared(
-            b.array(), null, fetchRowMetadataForParams(query), fetchRowMetadataForResults(result));
+            b.array(),
+            bResult.array(),
+            fetchRowMetadataForParams(query),
+            fetchRowMetadataForResults(result));
       } else if (this.primedRequest.then instanceof VoidResult) {
-        return new Prepared(b.array(), null, fetchRowMetadataForParams(query), rowMetadataForVoid);
+        return new Prepared(
+            b.array(), bResult.array(), fetchRowMetadataForParams(query), rowMetadataForVoid);
       } else if (this.primedRequest.then instanceof ErrorResult) {
         return new Prepared(
             b.array(),
-            null,
+            bResult.array(),
             fetchRowMetadataForParams(query),
             new RowsMetadata(new LinkedList<>(), null, null, null));
       }

--- a/common/src/main/java/com/datastax/oss/simulacron/common/utils/FrameUtils.java
+++ b/common/src/main/java/com/datastax/oss/simulacron/common/utils/FrameUtils.java
@@ -43,4 +43,18 @@ public class FrameUtils {
     return new Frame(
         4, false, 0, false, null, Collections.emptyMap(), Collections.emptyList(), message);
   }
+
+  public static Frame convertResponseMessage(Frame responseFrame, Message newMessage) {
+    return new Frame(
+        responseFrame.protocolVersion,
+        responseFrame.beta,
+        responseFrame.streamId,
+        responseFrame.tracing,
+        responseFrame.tracingId,
+        -1,
+        -1,
+        Frame.NO_PAYLOAD,
+        Collections.emptyList(),
+        newMessage);
+  }
 }

--- a/http-server/src/main/java/com/datastax/oss/simulacron/http/server/EndpointManager.java
+++ b/http-server/src/main/java/com/datastax/oss/simulacron/http/server/EndpointManager.java
@@ -416,9 +416,7 @@ public class EndpointManager implements HttpListener {
     router
         .route(HttpMethod.PUT, "/pause-reads/:clusterIdOrName/:datacenterIdOrName")
         .handler(this::pauseConnections);
-    router
-        .route(HttpMethod.PUT, "/pause-reads/:clusterIdOrName")
-        .handler(this::pauseConnections);
+    router.route(HttpMethod.PUT, "/pause-reads/:clusterIdOrName").handler(this::pauseConnections);
 
     // Resume reads for connections
     router

--- a/native-protocol-json/src/test/java/com/datastax/oss/simulacron/protocol/json/FrameSerializerTest.java
+++ b/native-protocol-json/src/test/java/com/datastax/oss/simulacron/protocol/json/FrameSerializerTest.java
@@ -72,20 +72,34 @@ public class FrameSerializerTest {
     String json = writer.writeValueAsString(frame);
     assertThat(json)
         .isEqualTo(
-            "{\n"
-                + "  \"protocol_version\" : 5,\n"
-                + "  \"beta\" : true,\n"
-                + "  \"stream_id\" : 10,\n"
-                + "  \"tracing_id\" : \"ce565629-e8e4-4f93-bdd4-9414b7d9d342\",\n"
-                + "  \"custom_payload\" : {\n"
-                + "    \"custom\" : \"Bwg=\"\n"
-                + "  },\n"
-                + "  \"warnings\" : [ \"Something went wrong\", \"Fix me!\" ],\n"
-                + "  \"message\" : {\n"
-                + "    \"type\" : \"OPTIONS\",\n"
-                + "    \"opcode\" : 5,\n"
-                + "    \"is_response\" : false\n"
-                + "  }\n"
+            "{"
+                + System.lineSeparator()
+                + "  \"protocol_version\" : 5,"
+                + System.lineSeparator()
+                + "  \"beta\" : true,"
+                + System.lineSeparator()
+                + "  \"stream_id\" : 10,"
+                + System.lineSeparator()
+                + "  \"tracing_id\" : \"ce565629-e8e4-4f93-bdd4-9414b7d9d342\","
+                + System.lineSeparator()
+                + "  \"custom_payload\" : {"
+                + System.lineSeparator()
+                + "    \"custom\" : \"Bwg=\""
+                + System.lineSeparator()
+                + "  },"
+                + System.lineSeparator()
+                + "  \"warnings\" : [ \"Something went wrong\", \"Fix me!\" ],"
+                + System.lineSeparator()
+                + "  \"message\" : {"
+                + System.lineSeparator()
+                + "    \"type\" : \"OPTIONS\","
+                + System.lineSeparator()
+                + "    \"opcode\" : 5,"
+                + System.lineSeparator()
+                + "    \"is_response\" : false"
+                + System.lineSeparator()
+                + "  }"
+                + System.lineSeparator()
                 + "}");
   }
 
@@ -105,22 +119,38 @@ public class FrameSerializerTest {
     String json = writer.writeValueAsString(frame);
     assertThat(json)
         .isEqualTo(
-            "{\n"
-                + "  \"protocol_version\" : 4,\n"
-                + "  \"beta\" : false,\n"
-                + "  \"stream_id\" : 10,\n"
-                + "  \"tracing_id\" : null,\n"
-                + "  \"custom_payload\" : { },\n"
-                + "  \"warnings\" : [ ],\n"
-                + "  \"message\" : {\n"
-                + "    \"type\" : \"STARTUP\",\n"
-                + "    \"opcode\" : 1,\n"
-                + "    \"is_response\" : false,\n"
-                + "    \"options\" : {\n"
-                + "      \"CQL_VERSION\" : \"3.0.0\",\n"
-                + "      \"COMPRESSION\" : \"LZ4\"\n"
-                + "    }\n"
-                + "  }\n"
+            "{"
+                + System.lineSeparator()
+                + "  \"protocol_version\" : 4,"
+                + System.lineSeparator()
+                + "  \"beta\" : false,"
+                + System.lineSeparator()
+                + "  \"stream_id\" : 10,"
+                + System.lineSeparator()
+                + "  \"tracing_id\" : null,"
+                + System.lineSeparator()
+                + "  \"custom_payload\" : { },"
+                + System.lineSeparator()
+                + "  \"warnings\" : [ ],"
+                + System.lineSeparator()
+                + "  \"message\" : {"
+                + System.lineSeparator()
+                + "    \"type\" : \"STARTUP\","
+                + System.lineSeparator()
+                + "    \"opcode\" : 1,"
+                + System.lineSeparator()
+                + "    \"is_response\" : false,"
+                + System.lineSeparator()
+                + "    \"options\" : {"
+                + System.lineSeparator()
+                + "      \"CQL_VERSION\" : \"3.0.0\","
+                + System.lineSeparator()
+                + "      \"COMPRESSION\" : \"LZ4\""
+                + System.lineSeparator()
+                + "    }"
+                + System.lineSeparator()
+                + "  }"
+                + System.lineSeparator()
                 + "}");
   }
 
@@ -140,19 +170,32 @@ public class FrameSerializerTest {
     String json = writer.writeValueAsString(frame);
     assertThat(json)
         .isEqualTo(
-            "{\n"
-                + "  \"protocol_version\" : 4,\n"
-                + "  \"beta\" : false,\n"
-                + "  \"stream_id\" : 10,\n"
-                + "  \"tracing_id\" : null,\n"
-                + "  \"custom_payload\" : { },\n"
-                + "  \"warnings\" : [ ],\n"
-                + "  \"message\" : {\n"
-                + "    \"type\" : \"AUTHENTICATE\",\n"
-                + "    \"opcode\" : 3,\n"
-                + "    \"is_response\" : true,\n"
-                + "    \"authenticator\" : \"AllowAllAuthenticator\"\n"
-                + "  }\n"
+            "{"
+                + System.lineSeparator()
+                + "  \"protocol_version\" : 4,"
+                + System.lineSeparator()
+                + "  \"beta\" : false,"
+                + System.lineSeparator()
+                + "  \"stream_id\" : 10,"
+                + System.lineSeparator()
+                + "  \"tracing_id\" : null,"
+                + System.lineSeparator()
+                + "  \"custom_payload\" : { },"
+                + System.lineSeparator()
+                + "  \"warnings\" : [ ],"
+                + System.lineSeparator()
+                + "  \"message\" : {"
+                + System.lineSeparator()
+                + "    \"type\" : \"AUTHENTICATE\","
+                + System.lineSeparator()
+                + "    \"opcode\" : 3,"
+                + System.lineSeparator()
+                + "    \"is_response\" : true,"
+                + System.lineSeparator()
+                + "    \"authenticator\" : \"AllowAllAuthenticator\""
+                + System.lineSeparator()
+                + "  }"
+                + System.lineSeparator()
                 + "}");
   }
 
@@ -175,22 +218,38 @@ public class FrameSerializerTest {
     String json = writer.writeValueAsString(frame);
     assertThat(json)
         .isEqualTo(
-            "{\n"
-                + "  \"protocol_version\" : 4,\n"
-                + "  \"beta\" : false,\n"
-                + "  \"stream_id\" : 10,\n"
-                + "  \"tracing_id\" : null,\n"
-                + "  \"custom_payload\" : { },\n"
-                + "  \"warnings\" : [ ],\n"
-                + "  \"message\" : {\n"
-                + "    \"type\" : \"SUPPORTED\",\n"
-                + "    \"opcode\" : 6,\n"
-                + "    \"is_response\" : true,\n"
-                + "    \"options\" : {\n"
-                + "      \"a\" : [ \"1\", \"2\", \"3\" ],\n"
-                + "      \"b\" : [ \"hello\" ]\n"
-                + "    }\n"
-                + "  }\n"
+            "{"
+                + System.lineSeparator()
+                + "  \"protocol_version\" : 4,"
+                + System.lineSeparator()
+                + "  \"beta\" : false,"
+                + System.lineSeparator()
+                + "  \"stream_id\" : 10,"
+                + System.lineSeparator()
+                + "  \"tracing_id\" : null,"
+                + System.lineSeparator()
+                + "  \"custom_payload\" : { },"
+                + System.lineSeparator()
+                + "  \"warnings\" : [ ],"
+                + System.lineSeparator()
+                + "  \"message\" : {"
+                + System.lineSeparator()
+                + "    \"type\" : \"SUPPORTED\","
+                + System.lineSeparator()
+                + "    \"opcode\" : 6,"
+                + System.lineSeparator()
+                + "    \"is_response\" : true,"
+                + System.lineSeparator()
+                + "    \"options\" : {"
+                + System.lineSeparator()
+                + "      \"a\" : [ \"1\", \"2\", \"3\" ],"
+                + System.lineSeparator()
+                + "      \"b\" : [ \"hello\" ]"
+                + System.lineSeparator()
+                + "    }"
+                + System.lineSeparator()
+                + "  }"
+                + System.lineSeparator()
                 + "}");
   }
 
@@ -216,30 +275,54 @@ public class FrameSerializerTest {
     String json = writer.writeValueAsString(frame);
     assertThat(json)
         .isEqualTo(
-            "{\n"
-                + "  \"protocol_version\" : 4,\n"
-                + "  \"beta\" : false,\n"
-                + "  \"stream_id\" : 10,\n"
-                + "  \"tracing_id\" : null,\n"
-                + "  \"custom_payload\" : { },\n"
-                + "  \"warnings\" : [ ],\n"
-                + "  \"message\" : {\n"
-                + "    \"type\" : \"QUERY\",\n"
-                + "    \"opcode\" : 7,\n"
-                + "    \"is_response\" : false,\n"
-                + "    \"query\" : \"select * from base\",\n"
-                + "    \"options\" : {\n"
-                + "      \"consistency\" : \"TWO\",\n"
-                + "      \"positional_values\" : [ \"AQID\", \"CgsM\" ],\n"
-                + "      \"named_values\" : { },\n"
-                + "      \"skip_metadata\" : false,\n"
-                + "      \"page_size\" : 1000,\n"
-                + "      \"paging_state\" : null,\n"
-                + "      \"serial_consistency\" : \"SERIAL\",\n"
-                + "      \"default_timestamp\" : 1513196542339,\n"
-                + "      \"keyspace\" : \"myks\"\n"
-                + "    }\n"
-                + "  }\n"
+            "{"
+                + System.lineSeparator()
+                + "  \"protocol_version\" : 4,"
+                + System.lineSeparator()
+                + "  \"beta\" : false,"
+                + System.lineSeparator()
+                + "  \"stream_id\" : 10,"
+                + System.lineSeparator()
+                + "  \"tracing_id\" : null,"
+                + System.lineSeparator()
+                + "  \"custom_payload\" : { },"
+                + System.lineSeparator()
+                + "  \"warnings\" : [ ],"
+                + System.lineSeparator()
+                + "  \"message\" : {"
+                + System.lineSeparator()
+                + "    \"type\" : \"QUERY\","
+                + System.lineSeparator()
+                + "    \"opcode\" : 7,"
+                + System.lineSeparator()
+                + "    \"is_response\" : false,"
+                + System.lineSeparator()
+                + "    \"query\" : \"select * from base\","
+                + System.lineSeparator()
+                + "    \"options\" : {"
+                + System.lineSeparator()
+                + "      \"consistency\" : \"TWO\","
+                + System.lineSeparator()
+                + "      \"positional_values\" : [ \"AQID\", \"CgsM\" ],"
+                + System.lineSeparator()
+                + "      \"named_values\" : { },"
+                + System.lineSeparator()
+                + "      \"skip_metadata\" : false,"
+                + System.lineSeparator()
+                + "      \"page_size\" : 1000,"
+                + System.lineSeparator()
+                + "      \"paging_state\" : null,"
+                + System.lineSeparator()
+                + "      \"serial_consistency\" : \"SERIAL\","
+                + System.lineSeparator()
+                + "      \"default_timestamp\" : 1513196542339,"
+                + System.lineSeparator()
+                + "      \"keyspace\" : \"myks\""
+                + System.lineSeparator()
+                + "    }"
+                + System.lineSeparator()
+                + "  }"
+                + System.lineSeparator()
                 + "}");
   }
 
@@ -277,33 +360,60 @@ public class FrameSerializerTest {
     String json = writer.writeValueAsString(frame);
     assertThat(json)
         .isEqualTo(
-            "{\n"
-                + "  \"protocol_version\" : 4,\n"
-                + "  \"beta\" : false,\n"
-                + "  \"stream_id\" : 10,\n"
-                + "  \"tracing_id\" : null,\n"
-                + "  \"custom_payload\" : { },\n"
-                + "  \"warnings\" : [ ],\n"
-                + "  \"message\" : {\n"
-                + "    \"type\" : \"QUERY\",\n"
-                + "    \"opcode\" : 7,\n"
-                + "    \"is_response\" : false,\n"
-                + "    \"query\" : \"select * from base\",\n"
-                + "    \"options\" : {\n"
-                + "      \"consistency\" : \"TWO\",\n"
-                + "      \"positional_values\" : [ ],\n"
-                + "      \"named_values\" : {\n"
-                + "        \"a\" : \"AQID\",\n"
-                + "        \"b\" : \"CgsM\"\n"
-                + "      },\n"
-                + "      \"skip_metadata\" : true,\n"
-                + "      \"page_size\" : 1000,\n"
-                + "      \"paging_state\" : \"Dw1yfVI=\",\n"
-                + "      \"serial_consistency\" : \"SERIAL\",\n"
-                + "      \"default_timestamp\" : 1513196542339,\n"
-                + "      \"keyspace\" : \"myks\"\n"
-                + "    }\n"
-                + "  }\n"
+            "{"
+                + System.lineSeparator()
+                + "  \"protocol_version\" : 4,"
+                + System.lineSeparator()
+                + "  \"beta\" : false,"
+                + System.lineSeparator()
+                + "  \"stream_id\" : 10,"
+                + System.lineSeparator()
+                + "  \"tracing_id\" : null,"
+                + System.lineSeparator()
+                + "  \"custom_payload\" : { },"
+                + System.lineSeparator()
+                + "  \"warnings\" : [ ],"
+                + System.lineSeparator()
+                + "  \"message\" : {"
+                + System.lineSeparator()
+                + "    \"type\" : \"QUERY\","
+                + System.lineSeparator()
+                + "    \"opcode\" : 7,"
+                + System.lineSeparator()
+                + "    \"is_response\" : false,"
+                + System.lineSeparator()
+                + "    \"query\" : \"select * from base\","
+                + System.lineSeparator()
+                + "    \"options\" : {"
+                + System.lineSeparator()
+                + "      \"consistency\" : \"TWO\","
+                + System.lineSeparator()
+                + "      \"positional_values\" : [ ],"
+                + System.lineSeparator()
+                + "      \"named_values\" : {"
+                + System.lineSeparator()
+                + "        \"a\" : \"AQID\","
+                + System.lineSeparator()
+                + "        \"b\" : \"CgsM\""
+                + System.lineSeparator()
+                + "      },"
+                + System.lineSeparator()
+                + "      \"skip_metadata\" : true,"
+                + System.lineSeparator()
+                + "      \"page_size\" : 1000,"
+                + System.lineSeparator()
+                + "      \"paging_state\" : \"Dw1yfVI=\","
+                + System.lineSeparator()
+                + "      \"serial_consistency\" : \"SERIAL\","
+                + System.lineSeparator()
+                + "      \"default_timestamp\" : 1513196542339,"
+                + System.lineSeparator()
+                + "      \"keyspace\" : \"myks\""
+                + System.lineSeparator()
+                + "    }"
+                + System.lineSeparator()
+                + "  }"
+                + System.lineSeparator()
                 + "}");
   }
 
@@ -323,20 +433,34 @@ public class FrameSerializerTest {
     String json = writer.writeValueAsString(frame);
     assertThat(json)
         .isEqualTo(
-            "{\n"
-                + "  \"protocol_version\" : 4,\n"
-                + "  \"beta\" : false,\n"
-                + "  \"stream_id\" : 10,\n"
-                + "  \"tracing_id\" : null,\n"
-                + "  \"custom_payload\" : { },\n"
-                + "  \"warnings\" : [ ],\n"
-                + "  \"message\" : {\n"
-                + "    \"type\" : \"PREPARE\",\n"
-                + "    \"opcode\" : 9,\n"
-                + "    \"is_response\" : false,\n"
-                + "    \"query\" : \"select * from base where belong=?\",\n"
-                + "    \"keyspace\" : \"your\"\n"
-                + "  }\n"
+            "{"
+                + System.lineSeparator()
+                + "  \"protocol_version\" : 4,"
+                + System.lineSeparator()
+                + "  \"beta\" : false,"
+                + System.lineSeparator()
+                + "  \"stream_id\" : 10,"
+                + System.lineSeparator()
+                + "  \"tracing_id\" : null,"
+                + System.lineSeparator()
+                + "  \"custom_payload\" : { },"
+                + System.lineSeparator()
+                + "  \"warnings\" : [ ],"
+                + System.lineSeparator()
+                + "  \"message\" : {"
+                + System.lineSeparator()
+                + "    \"type\" : \"PREPARE\","
+                + System.lineSeparator()
+                + "    \"opcode\" : 9,"
+                + System.lineSeparator()
+                + "    \"is_response\" : false,"
+                + System.lineSeparator()
+                + "    \"query\" : \"select * from base where belong=?\","
+                + System.lineSeparator()
+                + "    \"keyspace\" : \"your\""
+                + System.lineSeparator()
+                + "  }"
+                + System.lineSeparator()
                 + "}");
   }
 
@@ -372,31 +496,56 @@ public class FrameSerializerTest {
     String json = writer.writeValueAsString(frame);
     assertThat(json)
         .isEqualTo(
-            "{\n"
-                + "  \"protocol_version\" : 4,\n"
-                + "  \"beta\" : false,\n"
-                + "  \"stream_id\" : 10,\n"
-                + "  \"tracing_id\" : null,\n"
-                + "  \"custom_payload\" : { },\n"
-                + "  \"warnings\" : [ ],\n"
-                + "  \"message\" : {\n"
-                + "    \"type\" : \"EXECUTE\",\n"
-                + "    \"opcode\" : 10,\n"
-                + "    \"is_response\" : false,\n"
-                + "    \"id\" : \"AQIDBA==\",\n"
-                + "    \"result_metadata_id\" : \"BAIDBA==\",\n"
-                + "    \"options\" : {\n"
-                + "      \"consistency\" : \"TWO\",\n"
-                + "      \"positional_values\" : [ ],\n"
-                + "      \"named_values\" : { },\n"
-                + "      \"skip_metadata\" : true,\n"
-                + "      \"page_size\" : 1000,\n"
-                + "      \"paging_state\" : \"CBEaGw==\",\n"
-                + "      \"serial_consistency\" : \"SERIAL\",\n"
-                + "      \"default_timestamp\" : 1513196542339,\n"
-                + "      \"keyspace\" : \"myks\"\n"
-                + "    }\n"
-                + "  }\n"
+            "{"
+                + System.lineSeparator()
+                + "  \"protocol_version\" : 4,"
+                + System.lineSeparator()
+                + "  \"beta\" : false,"
+                + System.lineSeparator()
+                + "  \"stream_id\" : 10,"
+                + System.lineSeparator()
+                + "  \"tracing_id\" : null,"
+                + System.lineSeparator()
+                + "  \"custom_payload\" : { },"
+                + System.lineSeparator()
+                + "  \"warnings\" : [ ],"
+                + System.lineSeparator()
+                + "  \"message\" : {"
+                + System.lineSeparator()
+                + "    \"type\" : \"EXECUTE\","
+                + System.lineSeparator()
+                + "    \"opcode\" : 10,"
+                + System.lineSeparator()
+                + "    \"is_response\" : false,"
+                + System.lineSeparator()
+                + "    \"id\" : \"AQIDBA==\","
+                + System.lineSeparator()
+                + "    \"result_metadata_id\" : \"BAIDBA==\","
+                + System.lineSeparator()
+                + "    \"options\" : {"
+                + System.lineSeparator()
+                + "      \"consistency\" : \"TWO\","
+                + System.lineSeparator()
+                + "      \"positional_values\" : [ ],"
+                + System.lineSeparator()
+                + "      \"named_values\" : { },"
+                + System.lineSeparator()
+                + "      \"skip_metadata\" : true,"
+                + System.lineSeparator()
+                + "      \"page_size\" : 1000,"
+                + System.lineSeparator()
+                + "      \"paging_state\" : \"CBEaGw==\","
+                + System.lineSeparator()
+                + "      \"serial_consistency\" : \"SERIAL\","
+                + System.lineSeparator()
+                + "      \"default_timestamp\" : 1513196542339,"
+                + System.lineSeparator()
+                + "      \"keyspace\" : \"myks\""
+                + System.lineSeparator()
+                + "    }"
+                + System.lineSeparator()
+                + "  }"
+                + System.lineSeparator()
                 + "}");
   }
 
@@ -416,19 +565,32 @@ public class FrameSerializerTest {
     String json = writer.writeValueAsString(frame);
     assertThat(json)
         .isEqualTo(
-            "{\n"
-                + "  \"protocol_version\" : 4,\n"
-                + "  \"beta\" : false,\n"
-                + "  \"stream_id\" : 10,\n"
-                + "  \"tracing_id\" : null,\n"
-                + "  \"custom_payload\" : { },\n"
-                + "  \"warnings\" : [ ],\n"
-                + "  \"message\" : {\n"
-                + "    \"type\" : \"REGISTER\",\n"
-                + "    \"opcode\" : 11,\n"
-                + "    \"is_response\" : false,\n"
-                + "    \"event_types\" : [ \"SCHEMA_CHANGE\", \"TOPOLOGY_CHANGE\", \"STATUS_CHANGE\" ]\n"
-                + "  }\n"
+            "{"
+                + System.lineSeparator()
+                + "  \"protocol_version\" : 4,"
+                + System.lineSeparator()
+                + "  \"beta\" : false,"
+                + System.lineSeparator()
+                + "  \"stream_id\" : 10,"
+                + System.lineSeparator()
+                + "  \"tracing_id\" : null,"
+                + System.lineSeparator()
+                + "  \"custom_payload\" : { },"
+                + System.lineSeparator()
+                + "  \"warnings\" : [ ],"
+                + System.lineSeparator()
+                + "  \"message\" : {"
+                + System.lineSeparator()
+                + "    \"type\" : \"REGISTER\","
+                + System.lineSeparator()
+                + "    \"opcode\" : 11,"
+                + System.lineSeparator()
+                + "    \"is_response\" : false,"
+                + System.lineSeparator()
+                + "    \"event_types\" : [ \"SCHEMA_CHANGE\", \"TOPOLOGY_CHANGE\", \"STATUS_CHANGE\" ]"
+                + System.lineSeparator()
+                + "  }"
+                + System.lineSeparator()
                 + "}");
   }
 
@@ -458,25 +620,44 @@ public class FrameSerializerTest {
     String json = writer.writeValueAsString(frame);
     assertThat(json)
         .isEqualTo(
-            "{\n"
-                + "  \"protocol_version\" : 4,\n"
-                + "  \"beta\" : false,\n"
-                + "  \"stream_id\" : 10,\n"
-                + "  \"tracing_id\" : null,\n"
-                + "  \"custom_payload\" : { },\n"
-                + "  \"warnings\" : [ ],\n"
-                + "  \"message\" : {\n"
-                + "    \"type\" : \"BATCH\",\n"
-                + "    \"opcode\" : 13,\n"
-                + "    \"is_response\" : false,\n"
-                + "    \"type\" : \"UNLOGGED\",\n"
-                + "    \"queries_or_ids\" : [ \"select * from tbl\", \"CAcGKg==\", \"select * from world\" ],\n"
-                + "    \"values\" : [ [ ], [ \"AA==\" ], [ ] ],\n"
-                + "    \"consistency\" : \"TWO\",\n"
-                + "    \"serial_consistency\" : \"LOCAL_ONE\",\n"
-                + "    \"default_timestamp\" : 1513196542339,\n"
-                + "    \"keyspace\" : \"myks\"\n"
-                + "  }\n"
+            "{"
+                + System.lineSeparator()
+                + "  \"protocol_version\" : 4,"
+                + System.lineSeparator()
+                + "  \"beta\" : false,"
+                + System.lineSeparator()
+                + "  \"stream_id\" : 10,"
+                + System.lineSeparator()
+                + "  \"tracing_id\" : null,"
+                + System.lineSeparator()
+                + "  \"custom_payload\" : { },"
+                + System.lineSeparator()
+                + "  \"warnings\" : [ ],"
+                + System.lineSeparator()
+                + "  \"message\" : {"
+                + System.lineSeparator()
+                + "    \"type\" : \"BATCH\","
+                + System.lineSeparator()
+                + "    \"opcode\" : 13,"
+                + System.lineSeparator()
+                + "    \"is_response\" : false,"
+                + System.lineSeparator()
+                + "    \"type\" : \"UNLOGGED\","
+                + System.lineSeparator()
+                + "    \"queries_or_ids\" : [ \"select * from tbl\", \"CAcGKg==\", \"select * from world\" ],"
+                + System.lineSeparator()
+                + "    \"values\" : [ [ ], [ \"AA==\" ], [ ] ],"
+                + System.lineSeparator()
+                + "    \"consistency\" : \"TWO\","
+                + System.lineSeparator()
+                + "    \"serial_consistency\" : \"LOCAL_ONE\","
+                + System.lineSeparator()
+                + "    \"default_timestamp\" : 1513196542339,"
+                + System.lineSeparator()
+                + "    \"keyspace\" : \"myks\""
+                + System.lineSeparator()
+                + "  }"
+                + System.lineSeparator()
                 + "}");
   }
 
@@ -496,19 +677,32 @@ public class FrameSerializerTest {
     String json = writer.writeValueAsString(frame);
     assertThat(json)
         .isEqualTo(
-            "{\n"
-                + "  \"protocol_version\" : 4,\n"
-                + "  \"beta\" : false,\n"
-                + "  \"stream_id\" : 10,\n"
-                + "  \"tracing_id\" : null,\n"
-                + "  \"custom_payload\" : { },\n"
-                + "  \"warnings\" : [ ],\n"
-                + "  \"message\" : {\n"
-                + "    \"type\" : \"AUTHRESPONSE\",\n"
-                + "    \"opcode\" : 15,\n"
-                + "    \"is_response\" : false,\n"
-                + "    \"token\" : \"AA==\"\n"
-                + "  }\n"
+            "{"
+                + System.lineSeparator()
+                + "  \"protocol_version\" : 4,"
+                + System.lineSeparator()
+                + "  \"beta\" : false,"
+                + System.lineSeparator()
+                + "  \"stream_id\" : 10,"
+                + System.lineSeparator()
+                + "  \"tracing_id\" : null,"
+                + System.lineSeparator()
+                + "  \"custom_payload\" : { },"
+                + System.lineSeparator()
+                + "  \"warnings\" : [ ],"
+                + System.lineSeparator()
+                + "  \"message\" : {"
+                + System.lineSeparator()
+                + "    \"type\" : \"AUTHRESPONSE\","
+                + System.lineSeparator()
+                + "    \"opcode\" : 15,"
+                + System.lineSeparator()
+                + "    \"is_response\" : false,"
+                + System.lineSeparator()
+                + "    \"token\" : \"AA==\""
+                + System.lineSeparator()
+                + "  }"
+                + System.lineSeparator()
                 + "}");
   }
 }

--- a/native-server/src/test/java/com/datastax/oss/simulacron/server/BoundNodeTest.java
+++ b/native-server/src/test/java/com/datastax/oss/simulacron/server/BoundNodeTest.java
@@ -17,9 +17,7 @@ package com.datastax.oss.simulacron.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.datastax.oss.protocol.internal.Frame;
-import com.datastax.oss.protocol.internal.Message;
-import com.datastax.oss.protocol.internal.ProtocolConstants;
+import com.datastax.oss.protocol.internal.*;
 import com.datastax.oss.protocol.internal.request.Execute;
 import com.datastax.oss.protocol.internal.request.Options;
 import com.datastax.oss.protocol.internal.request.Prepare;
@@ -47,10 +45,11 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.local.LocalAddress;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timer;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
+
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -188,6 +187,69 @@ public class BoundNodeTest {
     } finally {
       loggedNode.clearLogs();
     }
+  }
+
+  @Test
+  public void shouldPrepareAndCreateInternalPrimeWithProtocolV5() {
+    Set<Integer> supportedVersions = new TreeSet<>();
+    supportedVersions.add(5);
+    FrameCodec codec = new FrameCodecWrapper(supportedVersions, new ProtocolV5ServerCodecs());
+
+    String query = "select * from unprimed";
+    Prepare prepare = new Prepare(query);
+    loggedChannel.writeInbound(new Frame(
+            5,
+            true,
+            0,
+            false,
+            null,
+            -1,
+            -1,
+            Collections.emptyMap(),
+            Collections.emptyList(),
+            prepare));
+    Frame frame = loggedChannel.readOutbound();
+
+    // Should get a prepared response back.
+    assertThat(frame.message).isInstanceOf(Prepared.class);
+
+    Prepared prepared = (Prepared) frame.message;
+
+    assertThat(codec.encode(frame)).isNotNull();
+
+    // Execute should succeed since bound node creates an internal prime.
+    Execute execute = new Execute(prepared.preparedQueryId, options);
+    loggedChannel.writeInbound(new Frame(
+            5,
+            true,
+            0,
+            false,
+            null,
+            -1,
+            -1,
+            Collections.emptyMap(),
+            Collections.emptyList(),
+            execute));
+    frame = loggedChannel.readOutbound();
+
+    // Should get a no rows response back.
+    assertThat(frame.message).isInstanceOf(Rows.class);
+
+    // Should be recorded in activity log
+    try {
+      assertThat(
+              loggedNode
+                      .getLogs()
+                      .getQueryLogs()
+                      .stream()
+                      .filter(ql -> ql.getQuery().equals(query))
+                      .findFirst())
+              .isPresent();
+    } finally {
+      loggedNode.clearLogs();
+    }
+
+    assertThat(codec.encode(frame)).isNotNull();
   }
 
   @Test

--- a/native-server/src/test/java/com/datastax/oss/simulacron/server/BoundNodeTest.java
+++ b/native-server/src/test/java/com/datastax/oss/simulacron/server/BoundNodeTest.java
@@ -17,7 +17,11 @@ package com.datastax.oss.simulacron.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.datastax.oss.protocol.internal.*;
+import com.datastax.oss.protocol.internal.Frame;
+import com.datastax.oss.protocol.internal.FrameCodec;
+import com.datastax.oss.protocol.internal.Message;
+import com.datastax.oss.protocol.internal.ProtocolConstants;
+import com.datastax.oss.protocol.internal.ProtocolV5ServerCodecs;
 import com.datastax.oss.protocol.internal.request.Execute;
 import com.datastax.oss.protocol.internal.request.Options;
 import com.datastax.oss.protocol.internal.request.Prepare;
@@ -45,11 +49,12 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.local.LocalAddress;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timer;
-
-import java.math.BigInteger;
-import java.net.InetAddress;
-import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -197,7 +202,8 @@ public class BoundNodeTest {
 
     String query = "select * from unprimed";
     Prepare prepare = new Prepare(query);
-    loggedChannel.writeInbound(new Frame(
+    loggedChannel.writeInbound(
+        new Frame(
             5,
             true,
             0,
@@ -219,7 +225,8 @@ public class BoundNodeTest {
 
     // Execute should succeed since bound node creates an internal prime.
     Execute execute = new Execute(prepared.preparedQueryId, options);
-    loggedChannel.writeInbound(new Frame(
+    loggedChannel.writeInbound(
+        new Frame(
             5,
             true,
             0,
@@ -239,12 +246,12 @@ public class BoundNodeTest {
     try {
       assertThat(
               loggedNode
-                      .getLogs()
-                      .getQueryLogs()
-                      .stream()
-                      .filter(ql -> ql.getQuery().equals(query))
-                      .findFirst())
-              .isPresent();
+                  .getLogs()
+                  .getQueryLogs()
+                  .stream()
+                  .filter(ql -> ql.getQuery().equals(query))
+                  .findFirst())
+          .isPresent();
     } finally {
       loggedNode.clearLogs();
     }


### PR DESCRIPTION
Also added some logic to the `FrameEncoder` so that these errors are caught, logged and a server error is returned to the client.

I was able to reproduce the bug with the test that I added.

I also fixed some unit tests that were failing on Windows because of the line separator.

Fixes #96 