### PR TITLE
fixes check statement match (issue #113)

### DIFF
--- a/common/src/test/java/com/datastax/oss/simulacron/common/request/StatementTest.java
+++ b/common/src/test/java/com/datastax/oss/simulacron/common/request/StatementTest.java
@@ -19,7 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/common/src/test/java/com/datastax/oss/simulacron/common/request/StatementTest.java
+++ b/common/src/test/java/com/datastax/oss/simulacron/common/request/StatementTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.simulacron.common.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class StatementTest {
+
+  private static final int PROTOCOL_VERSION = 4;
+  private static final String QUERY = "INSERT INTO a.c(c1, c2) VALUES (?, ?)";
+
+  private Object queryOrId;
+
+  public StatementTest(Object queryOrId) {
+    this.queryOrId = queryOrId;
+  }
+
+  @Parameterized.Parameters
+  public static Collection queryOrId() {
+    return Arrays.asList(QUERY, ByteBuffer.allocate(4).putInt(QUERY.hashCode()).array());
+  }
+
+  @Test
+  public void shouldMatchQuery() {
+    LinkedHashMap<String, String> paramTypes = new LinkedHashMap<>();
+    paramTypes.put("c1", "ascii");
+    paramTypes.put("c2", "ascii");
+
+    LinkedHashMap<String, Object> params = new LinkedHashMap<>();
+    params.put("c1", "c1");
+    params.put("c2", "c2");
+
+    List<ByteBuffer> positionalValues = new ArrayList<>(2);
+    positionalValues.add(ByteBuffer.wrap("c1".getBytes(StandardCharsets.UTF_8)));
+    positionalValues.add(ByteBuffer.wrap("c2".getBytes(StandardCharsets.UTF_8)));
+
+    Statement statement = new Statement(QUERY, paramTypes, params);
+    boolean result = statement.checkStatementMatch(PROTOCOL_VERSION, queryOrId, positionalValues);
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void shouldMatchQueryWhenParamValuesAreNotSet() {
+    LinkedHashMap<String, String> paramTypes = new LinkedHashMap<>();
+    paramTypes.put("c1", "ascii");
+    paramTypes.put("c2", "ascii");
+
+    List<ByteBuffer> positionalValues = new ArrayList<>(2);
+    positionalValues.add(ByteBuffer.wrap("any".getBytes(StandardCharsets.UTF_8)));
+    positionalValues.add(ByteBuffer.wrap("any".getBytes(StandardCharsets.UTF_8)));
+
+    Statement statement = new Statement(QUERY, paramTypes, null);
+    boolean result = statement.checkStatementMatch(PROTOCOL_VERSION, queryOrId, positionalValues);
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void shouldNotMatchQueryEvenWhenParamsAreNotSet() {
+    LinkedHashMap<String, String> paramTypes = new LinkedHashMap<>();
+    paramTypes.put("c1", "ascii");
+    paramTypes.put("c2", "ascii");
+
+    List<ByteBuffer> positionalValues = new ArrayList<>(2);
+    positionalValues.add(ByteBuffer.wrap("c1".getBytes(StandardCharsets.UTF_8)));
+    positionalValues.add(ByteBuffer.wrap("c2".getBytes(StandardCharsets.UTF_8)));
+
+    Statement statement = new Statement("Not matching query", paramTypes, null);
+    boolean result = statement.checkStatementMatch(PROTOCOL_VERSION, queryOrId, positionalValues);
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void shouldNotMatchWhenWrongNumberOfArguments() {
+    LinkedHashMap<String, String> paramTypes = new LinkedHashMap<>();
+    paramTypes.put("c1", "ascii");
+    paramTypes.put("c2", "ascii");
+
+    LinkedHashMap<String, Object> params = new LinkedHashMap<>();
+    params.put("c1", "c1");
+    params.put("c2", "c2");
+
+    List<ByteBuffer> positionalValues = new ArrayList<>(2);
+    positionalValues.add(ByteBuffer.wrap("c1".getBytes(StandardCharsets.UTF_8)));
+
+    Statement statement = new Statement(QUERY, paramTypes, params);
+    boolean result = statement.checkStatementMatch(PROTOCOL_VERSION, queryOrId, positionalValues);
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void shouldNotMatchWhenWrongOrderOfArguments() {
+    LinkedHashMap<String, String> paramTypes = new LinkedHashMap<>();
+    paramTypes.put("c1", "ascii");
+    paramTypes.put("c2", "ascii");
+
+    LinkedHashMap<String, Object> params = new LinkedHashMap<>();
+    params.put("c1", "c1");
+    params.put("c2", "c2");
+
+    List<ByteBuffer> positionalValues = new ArrayList<>(2);
+    positionalValues.add(ByteBuffer.wrap("c2".getBytes(StandardCharsets.UTF_8)));
+    positionalValues.add(ByteBuffer.wrap("c1".getBytes(StandardCharsets.UTF_8)));
+
+    Statement statement = new Statement(QUERY, paramTypes, params);
+    boolean result = statement.checkStatementMatch(PROTOCOL_VERSION, queryOrId, positionalValues);
+
+    assertThat(result).isFalse();
+  }
+}

--- a/http-server/src/test/java/com/datastax/oss/simulacron/http/server/HttpPrimeBatchIntegrationTest.java
+++ b/http-server/src/test/java/com/datastax/oss/simulacron/http/server/HttpPrimeBatchIntegrationTest.java
@@ -136,7 +136,7 @@ public class HttpPrimeBatchIntegrationTest {
     String contactPoint = HttpTestUtil.getContactPointString(server.getCluster(), 0);
     BoundStatement bt =
         HttpTestUtil.getBoundStatementNamed(
-            query, contactPoint, ImmutableMap.<String, String>of("c1", "c1", "c2", "c2"));
+            query, contactPoint, ImmutableMap.<String, String>of("c2", "c2", "c1", "c1"));
 
     Map<String, String> simple_param_types = new HashMap<String, String>();
     simple_param_types.put("column1", "ascii");
@@ -148,9 +148,11 @@ public class HttpPrimeBatchIntegrationTest {
 
     Map<String, String> param_types = new HashMap<String, String>();
     param_types.put("c1", "ascii");
+    param_types.put("c2", "ascii");
 
     Map<String, Object> params_batch = new HashMap<String, Object>();
     params_batch.put("c1", "c1");
+    params_batch.put("c2", "c2");
 
     RequestPrime primeBatch =
         HttpTestUtil.createParameterizedBatch(


### PR DESCRIPTION
I have sync checkStatementMatch to be same when query is string or hashcode.
One integration test was failing that I have changed to show that Batch Statement are always matched on positional values.
I have also added specific StatementTest to cover more scenarios closer to the class.
